### PR TITLE
add lock to db

### DIFF
--- a/db/db_test.go
+++ b/db/db_test.go
@@ -3,7 +3,9 @@ package db
 import (
 	"testing"
 
+	"github.com/attic-labs/noms/go/types"
 	"github.com/stretchr/testify/assert"
+	"roci.dev/diff-server/kv"
 )
 
 func TestGenesis(t *testing.T) {
@@ -13,4 +15,25 @@ func TestGenesis(t *testing.T) {
 	assert.True(db.Head().Data(db.Noms()).Empty())
 }
 
-// hmmm.. we seem to have removed every test.
+func TestPutData(t *testing.T) {
+	assert := assert.New(t)
+	db, _ := LoadTempDB(assert)
+	genesis := db.Head()
+	me := kv.NewMap(db.Noms()).Edit()
+	assert.NoError(me.Set("key", types.Bool(true)))
+	m := me.Build()
+
+	c1, err := db.PutData(m, 1)
+	assert.NoError(err)
+	assert.False(genesis.Original.Equals(c1.Original))
+	assert.True(c1.Original.Equals(db.Head().Original))
+	assert.True(m.NomsMap().Value().Equals(c1.Data(db.Noms())))
+	assert.True(types.Number(1).Equals(c1.Value.LastMutationID))
+
+	c2, err := db.PutData(m, 2)
+	assert.NoError(err)
+	assert.True(c2.Original.Equals(db.Head().Original))
+	assert.True(types.Number(2).Equals(c2.Value.LastMutationID))
+}
+
+// hmmm.. we seem to have removed most tests.

--- a/db/diff_test.go
+++ b/db/diff_test.go
@@ -34,7 +34,7 @@ func TestDiff(t *testing.T) {
 			"change-1",
 			func() {
 				m := kv.NewMapForTest(db.Noms(), "foo", `"bar"`, "hot", `"dog"`)
-				err := db.PutData(m, 0 /*lastMutationID*/)
+				_, err := db.PutData(m, 0 /*lastMutationID*/)
 				assert.NoError(err)
 			},
 			[]kv.Operation{
@@ -55,7 +55,7 @@ func TestDiff(t *testing.T) {
 			"change-2",
 			func() {
 				m := kv.NewMapForTest(db.Noms(), "foo", `"baz"`, "mon", `"key"`)
-				err := db.PutData(m, 0 /*lastMutationID*/)
+				_, err := db.PutData(m, 0 /*lastMutationID*/)
 				assert.NoError(err)
 			},
 			[]kv.Operation{
@@ -92,7 +92,7 @@ func TestDiff(t *testing.T) {
 					assert.NoError(me.Set(types.String(s), types.String(s)))
 				}
 				m := me.Build()
-				err := db.PutData(m, 0 /*lastMutationID*/)
+				_, err := db.PutData(m, 0 /*lastMutationID*/)
 				assert.NoError(err)
 			},
 			[]kv.Operation{
@@ -150,7 +150,7 @@ func TestDiff(t *testing.T) {
 			"invalid-checksum",
 			func() {
 				m := kv.NewMapForTest(db.Noms(), "foo", `"bar"`)
-				err := db.PutData(m, 0 /*lastMutationID*/)
+				_, err := db.PutData(m, 0 /*lastMutationID*/)
 				assert.NoError(err)
 				fromChecksum = "00000000"
 			},
@@ -197,13 +197,13 @@ func TestDiff(t *testing.T) {
 	}
 
 	for _, t := range tc {
-		fromID = db.head.Original.Hash()
+		fromID = db.Head().Original.Hash()
 		var err error
-		fromChecksum = string(db.head.Value.Checksum)
+		fromChecksum = string(db.Head().Value.Checksum)
 		t.f()
 		c, err := kv.ChecksumFromString(fromChecksum)
 		assert.NoError(err)
-		r, err := db.Diff(fromID, *c)
+		r, err := db.Diff(fromID, *c, db.Head())
 		if t.expectedError == "" {
 			assert.NoError(err, t.label)
 			expected, err := json.Marshal(t.expectedDiff)

--- a/serve/pull_test.go
+++ b/serve/pull_test.go
@@ -241,7 +241,7 @@ func TestAPI(t *testing.T) {
 		db, err := db.New(noms.GetDataset("client/clientid"))
 		assert.NoError(err)
 		m := kv.NewMapForTest(noms, "foo", `"bar"`)
-		err = db.PutData(m, 1 /*lastMutationID*/)
+		_, err = db.PutData(m, 1 /*lastMutationID*/)
 		assert.NoError(err)
 
 		msg := fmt.Sprintf("test case %d: %s", i, t.pullReq)


### PR DESCRIPTION
- add a lock around db.head
- fix instances where we read head multiple times in the same operation and assume it hasn't changed
- use db.Head() where possible

fixes https://github.com/rocicorp/replicache/issues/42