### PR TITLE
logging improvements

### DIFF
--- a/cmd/diffs/main.go
+++ b/cmd/diffs/main.go
@@ -36,7 +36,7 @@ func main() {
 }
 
 func impl(args []string, in io.Reader, out, errs io.Writer, exit func(int)) {
-	zlog.Logger = zlog.Output(zl.ConsoleWriter{Out: os.Stderr})
+	zlog.Logger = zlog.Output(zl.ConsoleWriter{Out: os.Stderr, TimeFormat: "02 Jan 06 15:04:05.000 -0700"})
 	l := log.Default()
 
 	app := kingpin.New("diffs", "")

--- a/serve/client_view.go
+++ b/serve/client_view.go
@@ -14,7 +14,7 @@ type ClientViewGetter struct{}
 
 // Get fetches a client view. It returns an error if the response from the data layer doesn't have
 // a lastMutationID.
-func (g ClientViewGetter) Get(url string, req servetypes.ClientViewRequest, authToken string) (servetypes.ClientViewResponse, int, error) {
+func (g ClientViewGetter) Get(url string, req servetypes.ClientViewRequest, authToken string, syncID string) (servetypes.ClientViewResponse, int, error) {
 	reqBody, err := json.Marshal(req)
 	if err != nil {
 		return servetypes.ClientViewResponse{}, 0, fmt.Errorf("could not marshal ClientViewRequest: %w", err)
@@ -24,6 +24,7 @@ func (g ClientViewGetter) Get(url string, req servetypes.ClientViewRequest, auth
 		return servetypes.ClientViewResponse{}, 0, fmt.Errorf("could not create client view http request: %w", err)
 	}
 	httpReq.Header.Add("Authorization", authToken)
+	httpReq.Header.Add("X-Replicache-SyncID", syncID)
 	httpResp, err := http.DefaultClient.Do(httpReq)
 	if err != nil {
 		return servetypes.ClientViewResponse{}, 0, fmt.Errorf("error sending client view http request: %w", err)

--- a/serve/client_view_test.go
+++ b/serve/client_view_test.go
@@ -68,12 +68,13 @@ func TestClientViewGetter_Get(t *testing.T) {
 				err := json.NewDecoder(r.Body).Decode(&reqBody)
 				assert.NoError(err, tt.name)
 				assert.Equal(tt.clientViewAuth, r.Header.Get("Authorization"), tt.name)
+				assert.Equal("syncID", r.Header.Get("X-Replicache-SyncID"), tt.name)
 				w.WriteHeader(tt.respCode)
 				w.Write([]byte(tt.respBody))
 			}))
 
 			g := ClientViewGetter{}
-			got, gotCode, err := g.Get(server.URL, tt.req, tt.clientViewAuth)
+			got, gotCode, err := g.Get(server.URL, tt.req, tt.clientViewAuth, "syncID")
 			assert.Equal(tt.wantCode, gotCode)
 			if tt.wantErr == "" {
 				assert.NoError(err)

--- a/serve/prod/prod.go
+++ b/serve/prod/prod.go
@@ -25,10 +25,15 @@ const (
 )
 
 var (
-	svc = serve.NewService("aws:replicant/aa-replicant2", accounts.Accounts(), "", serve.ClientViewGetter{}, false)
+	svc                = serve.NewService("aws:replicant/aa-replicant2", accounts.Accounts(), "", serve.ClientViewGetter{}, false)
+	headerLogWhitelist = []string{"Authorization", "Content-Type", "Host", "X-Replicache-SyncID"}
 )
 
 func init() {
+	// Zeit now has a 4kb log limit per request, so set up some aggressive HTTP log filters.
+	loghttp.Filters = append(loghttp.Filters, loghttp.NewBodyTrimmer(500).Filter)
+	loghttp.Filters = append(loghttp.Filters, loghttp.NewHeaderWhitelist(headerLogWhitelist).Filter)
+
 	zl.SetGlobalLevel(zl.DebugLevel)
 	zlog.Logger = zlog.Output(zl.ConsoleWriter{Out: os.Stderr, TimeFormat: "02 Jan 06 15:04:05.000 -0700", NoColor: true})
 	spec.GetAWSSession = func() *session.Session {

--- a/serve/prod/prod.go
+++ b/serve/prod/prod.go
@@ -30,7 +30,7 @@ var (
 
 func init() {
 	zl.SetGlobalLevel(zl.DebugLevel)
-	zlog.Logger = zlog.Output(zl.ConsoleWriter{Out: os.Stderr, NoColor: true})
+	zlog.Logger = zlog.Output(zl.ConsoleWriter{Out: os.Stderr, TimeFormat: "02 Jan 06 15:04:05.000 -0700", NoColor: true})
 	spec.GetAWSSession = func() *session.Session {
 		return session.Must(session.NewSession(
 			aws.NewConfig().WithRegion(aws_region).WithCredentials(

--- a/serve/prod/prod.go
+++ b/serve/prod/prod.go
@@ -31,7 +31,7 @@ var (
 
 func init() {
 	// Zeit now has a 4kb log limit per request, so set up some aggressive HTTP log filters.
-	loghttp.Filters = append(loghttp.Filters, loghttp.NewBodyTrimmer(500).Filter)
+	loghttp.Filters = append(loghttp.Filters, loghttp.NewBodyElider(500).Filter)
 	loghttp.Filters = append(loghttp.Filters, loghttp.NewHeaderWhitelist(headerLogWhitelist).Filter)
 
 	zl.SetGlobalLevel(zl.DebugLevel)

--- a/serve/pull_test.go
+++ b/serve/pull_test.go
@@ -252,6 +252,7 @@ func TestAPI(t *testing.T) {
 		if t.authHeader != "" {
 			req.Header.Set("Authorization", t.authHeader)
 		}
+		req.Header.Set("X-Replicache-SyncID", "syncID")
 		resp := httptest.NewRecorder()
 		s.pull(resp, req, log.Default())
 
@@ -275,6 +276,7 @@ func TestAPI(t *testing.T) {
 			assert.Equal(expectedCVURL, fcvg.gotURL, msg)
 			assert.Equal(t.expCVAuth, fcvg.gotAuth, msg)
 			assert.Equal("clientid", fcvg.gotClientID)
+			assert.Equal("syncID", fcvg.gotSyncID)
 		}
 	}
 }
@@ -288,12 +290,14 @@ type fakeClientViewGet struct {
 	gotURL      string
 	gotAuth     string
 	gotClientID string
+	gotSyncID   string
 }
 
-func (f *fakeClientViewGet) Get(url string, req servetypes.ClientViewRequest, authToken string) (servetypes.ClientViewResponse, int, error) {
+func (f *fakeClientViewGet) Get(url string, req servetypes.ClientViewRequest, authToken string, syncID string) (servetypes.ClientViewResponse, int, error) {
 	f.called = true
 	f.gotURL = url
 	f.gotAuth = authToken
 	f.gotClientID = req.ClientID
+	f.gotSyncID = syncID
 	return f.resp, f.code, f.err
 }

--- a/serve/service.go
+++ b/serve/service.go
@@ -73,7 +73,12 @@ func NewService(storageRoot string, accounts []Account, overrideClientViewURL st
 }
 
 func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	l := log.Default().With().Str("req", r.URL.String()).Uint64("rid", atomic.AddUint64(&s.reqID, 1)).Logger()
+	c := log.Default().With().Str("req", r.URL.String()).Uint64("rid", atomic.AddUint64(&s.reqID, 1))
+	syncID := r.Header.Get("X-Replicache-SyncID")
+	if syncID != "" {
+		c = c.Str("syncID", syncID)
+	}
+	l := c.Logger()
 	l.Info().Msg("received request")
 
 	defer func() {

--- a/serve/service.go
+++ b/serve/service.go
@@ -47,7 +47,7 @@ type Service struct {
 }
 
 type clientViewGetter interface {
-	Get(url string, req servetypes.ClientViewRequest, authToken string) (servetypes.ClientViewResponse, int, error)
+	Get(url string, req servetypes.ClientViewRequest, authToken string, syncID string) (servetypes.ClientViewResponse, int, error)
 }
 
 // Account is information about a customer of Replicant. This is a stand-in for what will eventually be

--- a/util/loghttp/filter.go
+++ b/util/loghttp/filter.go
@@ -1,0 +1,114 @@
+package loghttp
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+)
+
+// FilterFunc filters an HTTP request or response dump, eg to remove or redact
+// header lines. A FilterFunc must return a valid HTTP dump (otherwise
+// they cannot be chained).
+type FilterFunc func([]byte) []byte
+
+// HeaderWhitelist is a FilterFunc that removes all headers not on
+// its whitelist. An empty whitelist filters all headers.
+type HeaderWhitelist struct {
+	re *regexp.Regexp
+}
+
+// NewHeaderWhitelist returns a new HeaderWhitelist that filters
+// all but the headers listed in whitelist.
+func NewHeaderWhitelist(whitelist []string) HeaderWhitelist {
+	// Build a regexp that will match header lines on the whitelist.
+	// Default to matching none.
+	reStr := "^$"
+	if len(whitelist) > 0 {
+		reStr = fmt.Sprintf(`^(%s`, whitelist[0])
+		for i := 1; i < len(whitelist); i++ {
+			reStr = fmt.Sprintf("%s|%s", reStr, whitelist[i])
+		}
+		reStr = fmt.Sprintf("%s):", reStr)
+	}
+	return HeaderWhitelist{regexp.MustCompile(reStr)}
+}
+
+// Filter filters the given HTTP request/response dump.
+func (hw HeaderWhitelist) Filter(httpReq []byte) []byte {
+	// Split the header lines on CRLF.
+	endHeadersIndex := bytes.Index(httpReq, []byte("\r\n\r\n"))
+	if endHeadersIndex == -1 {
+		return httpReq
+	}
+	headerLines := bytes.Split(httpReq[:endHeadersIndex], []byte("\r\n"))
+	if len(headerLines) == 0 {
+		return httpReq
+	}
+
+	filtered := make([]byte, len(httpReq))
+
+	// Copy the request or status line to output.
+	l := copy(filtered, headerLines[0])
+	l += copy(filtered[l:], []byte("\r\n"))
+
+	// Filter the header lines.
+	for i := 1; i < len(headerLines); i++ {
+		if hw.re.Match(headerLines[i]) {
+			l += copy(filtered[l:], headerLines[i])
+			l += copy(filtered[l:], []byte("\r\n"))
+		}
+	}
+	l += copy(filtered[l:], []byte("\r\n"))
+
+	// If no body we're done. Else copy the body.
+	if endHeadersIndex+3 == len(httpReq) {
+		return filtered[:l]
+	}
+	l += copy(filtered[l:], httpReq[endHeadersIndex+4:])
+
+	return filtered[:l]
+}
+
+// BodyTrimmer is a FilterFunc that limits the size of the HTTP
+// request/response body to max bytes. Bytes are clipped from the
+// middle of the body, replaced with "...".
+type BodyTrimmer struct {
+	max int
+}
+
+// NewBodyTrimmer returns a new BodyTrimmer. The minimum value for
+// max is 6 to avoid annoying checks on negative indexes when trimming.
+func NewBodyTrimmer(max int) BodyTrimmer {
+	if max < 6 {
+		max = 6
+	}
+	return BodyTrimmer{max}
+}
+
+// Filter filters an HTTP request or response body to max size.
+func (bt BodyTrimmer) Filter(httpReq []byte) []byte {
+	endHeadersIndex := bytes.Index(httpReq, []byte("\r\n\r\n"))
+	beginBodyIndex := 0
+	// The dump code doesn't currently dump HTTP response headers.
+	// In that case beginBodyIndex is zero. If we do have headers,
+	// the body begins after the CRLFCRLF.
+	if endHeadersIndex != -1 {
+		beginBodyIndex = endHeadersIndex + 4
+	}
+	// If no body, we're done.
+	if beginBodyIndex > len(httpReq) {
+		return httpReq
+	}
+	
+	body := httpReq[beginBodyIndex:]
+	if len(body) <= bt.max {
+		return httpReq
+	}
+	size := beginBodyIndex + bt.max
+	filtered := make([]byte, size)
+	l := copy(filtered, httpReq[:beginBodyIndex])
+	l += copy(filtered[l:], body[:bt.max/2])
+	l += copy(filtered[l:], []byte("..."))
+	l += copy(filtered[l:], body[len(body)-(size-l):])
+	return filtered[:l]
+}

--- a/util/loghttp/filter_test.go
+++ b/util/loghttp/filter_test.go
@@ -1,0 +1,151 @@
+package loghttp
+
+import (
+	"testing"
+)
+
+func TestHeaderWhitelist_Filter(t *testing.T) {
+	tests := []struct {
+		name      string
+		whitelist []string
+		httpReq   string
+		want      string
+	}{
+		{
+			"not http: empty input",
+			[]string{},
+			"",
+			"",
+		},
+		{
+			"not http: random text",
+			[]string{},
+			"This is not HTTP",
+			"This is not HTTP",
+		},
+		{
+			"request: empty whitelist, no headers or body",
+			[]string{},
+			"GET / HTTP/1.0\r\n\r\n",
+			"GET / HTTP/1.0\r\n\r\n",
+		},
+		{
+			"request: empty whitelist, no headers or body",
+			[]string{},
+			"GET / HTTP/1.0\r\n\r\n",
+			"GET / HTTP/1.0\r\n\r\n",
+		},
+		{
+			"request: empty whitelist, headers no body",
+			[]string{},
+			"GET / HTTP/1.0\r\nFoo: bar\r\n\r\n",
+			"GET / HTTP/1.0\r\n\r\n",
+		},
+		{
+			"request: empty whitelist, headers and body",
+			[]string{},
+			"GET / HTTP/1.0\r\nFoo: bar\r\n\r\nbody",
+			"GET / HTTP/1.0\r\n\r\nbody",
+		},
+		{
+			"request: filters no headers",
+			[]string{"Bar", "Foo"},
+			"GET / HTTP/1.0\r\nFoo: bar\r\nBar: baz\r\n\r\nbody",
+			"GET / HTTP/1.0\r\nFoo: bar\r\nBar: baz\r\n\r\nbody",
+		},
+		{
+			"request: filters some headers",
+			[]string{"No-Such-Header", "Bar"},
+			"GET / HTTP/1.0\r\nFoo: bar\r\nBar: baz\r\nBonk: boof\r\n\r\nbody",
+			"GET / HTTP/1.0\r\nBar: baz\r\n\r\nbody",
+		},
+		{
+			"request: filters all headers",
+			[]string{"No-Such-Header"},
+			"GET / HTTP/1.0\r\nFoo: bar\r\nBar: baz\r\nBonk: boof\r\n\r\nbody",
+			"GET / HTTP/1.0\r\n\r\nbody",
+		},
+		{
+			"response: filters some headers",
+			[]string{"No-Such-Header", "Bar"},
+			"HTTP/1.0 200 OK\r\nFoo: bar\r\nBar: baz\r\nBonk: boof\r\n\r\nbody",
+			"HTTP/1.0 200 OK\r\nBar: baz\r\n\r\nbody",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hw := NewHeaderWhitelist(tt.whitelist)
+			got := string(hw.Filter([]byte(tt.httpReq)))
+			if got != tt.want {
+				t.Errorf("HeaderWhitelist.Filter() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBodyTrimmer_Filter(t *testing.T) {
+	tests := []struct {
+		name    string
+		max     int
+		httpReq string
+		want    string
+	}{
+		{
+			"not http: empty input",
+			10,
+			"",
+			"",
+		},
+		{
+			"just a body",
+			10,
+			"012345678901234567890",
+			"01234...90",
+		},
+		{
+			"request: no body",
+			10,
+			"GET / HTTP/1.0\r\n\r\n",
+			"GET / HTTP/1.0\r\n\r\n",
+		},
+		{
+			"response: no body",
+			10,
+			"HTTP/1.0 200 OK\r\n\r\n",
+			"HTTP/1.0 200 OK\r\n\r\n",
+		},
+		{
+			"request: body size smaller than max",
+			10,
+			"GET / HTTP/1.0\r\nFoo: bar\r\n\r\nbody",
+			"GET / HTTP/1.0\r\nFoo: bar\r\n\r\nbody",
+		},
+		{
+			"request: body size equal to max",
+			10,
+			"GET / HTTP/1.0\r\nFoo: bar\r\n\r\n0123456789",
+			"GET / HTTP/1.0\r\nFoo: bar\r\n\r\n0123456789",
+		},
+		{
+			"request: body size larger than max",
+			10,
+			"GET / HTTP/1.0\r\nFoo: bar\r\n\r\n012345678901234567890",
+			"GET / HTTP/1.0\r\nFoo: bar\r\n\r\n01234...90",
+		},
+		{
+			"request: max too small",
+			1,
+			"GET / HTTP/1.0\r\nFoo: bar\r\n\r\n012345",
+			"GET / HTTP/1.0\r\nFoo: bar\r\n\r\n012345",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bt := NewBodyTrimmer(tt.max)
+			got := string(bt.Filter([]byte(tt.httpReq)))
+			if got != tt.want {
+				t.Errorf("BodyTrimmer.Filter() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/util/loghttp/filter_test.go
+++ b/util/loghttp/filter_test.go
@@ -83,7 +83,7 @@ func TestHeaderWhitelist_Filter(t *testing.T) {
 	}
 }
 
-func TestBodyTrimmer_Filter(t *testing.T) {
+func TestBodyElider_Filter(t *testing.T) {
 	tests := []struct {
 		name    string
 		max     int
@@ -141,10 +141,10 @@ func TestBodyTrimmer_Filter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			bt := NewBodyTrimmer(tt.max)
-			got := string(bt.Filter([]byte(tt.httpReq)))
+			be := NewBodyElider(tt.max)
+			got := string(be.Filter([]byte(tt.httpReq)))
 			if got != tt.want {
-				t.Errorf("BodyTrimmer.Filter() = %q, want %q", got, tt.want)
+				t.Errorf("BodyElider.Filter() = %q, want %q", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
- add tz, ms to log lines
- add syncID to log lines
- filter HTTP request/response logs to (be more likely to) fit zeit's 4kb limit

progress towards https://github.com/rocicorp/replicache-client/pull/71