### PR TITLE
factor functionality into middleware

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gibson042/canonicaljson-go v1.0.3
 	github.com/golang/protobuf v1.3.1 // indirect
+	github.com/justinas/alice v1.2.0
 	github.com/motemen/go-loghttp v0.0.0-20170804080138-974ac5ceac27
 	github.com/motemen/go-nuts v0.0.0-20190725124253-1d2432db96b0 // indirect
 	github.com/onsi/ginkgo v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d h1:c93kUJDtVAXFEhsCh5
 github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
 github.com/julienschmidt/httprouter v1.2.0 h1:TDTW5Yz1mjftljbcKqRcrYhd4XeOoI98t+9HbQbYf7g=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/justinas/alice v1.2.0 h1:+MHSA/vccVCF4Uq37S42jwlkvI2Xzl7zTPCN5BnZNVo=
+github.com/justinas/alice v1.2.0/go.mod h1:fN5HRH/reO/zrUflLfTN43t3vXvKzvZIENsNEe7i7qA=
 github.com/kch42/buzhash v0.0.0-20160816060738-9bdec3dec7c6 h1:l6Y3mFnF46A+CeZsTrT8kVIuhayq1266oxWpDKE7hnQ=
 github.com/kch42/buzhash v0.0.0-20160816060738-9bdec3dec7c6/go.mod h1:UtDV9qK925GVmbdjR+e1unqoo+wGWNHHC6XB1Eu6wpE=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/serve/hello.go
+++ b/serve/hello.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"net/http"
 
-	zl "github.com/rs/zerolog"
 	"roci.dev/diff-server/util/version"
 )
 
 // hello prints a hello message to let users know the server is running.
-func (s *Service) hello(w http.ResponseWriter, r *http.Request, l zl.Logger) {
+func (s *Service) hello(w http.ResponseWriter, r *http.Request) {
+	l := logger(r)
 	if r.Method != "GET" {
 		unsupportedMethodError(w, r.Method, l)
 		return

--- a/serve/hello_test.go
+++ b/serve/hello_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"roci.dev/diff-server/util/log"
 	"roci.dev/diff-server/util/time"
 )
 
@@ -38,7 +37,7 @@ func TestHello(t *testing.T) {
 		msg := fmt.Sprintf("test case %d", i)
 		req := httptest.NewRequest(t.method, "/hello", nil)
 		resp := httptest.NewRecorder()
-		s.hello(resp, req, log.Default())
+		s.hello(resp, req)
 
 		body := bytes.Buffer{}
 		_, err := io.Copy(&body, resp.Result().Body)

--- a/serve/inject.go
+++ b/serve/inject.go
@@ -7,13 +7,14 @@ import (
 	"net/http"
 
 	"github.com/pkg/errors"
-	zl "github.com/rs/zerolog"
 	servetypes "roci.dev/diff-server/serve/types"
 )
 
 // inject inserts a client view into the cache. This is primarily useful for testing without
 // having to have a data layer running.
-func (s *Service) inject(w http.ResponseWriter, r *http.Request, l zl.Logger) {
+func (s *Service) inject(w http.ResponseWriter, r *http.Request) {
+	l := logger(r)
+
 	if !s.enableInject {
 		w.WriteHeader(http.StatusNotFound)
 		return

--- a/serve/inject_test.go
+++ b/serve/inject_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/attic-labs/noms/go/types"
 	"github.com/stretchr/testify/assert"
 
-	"roci.dev/diff-server/util/log"
 	"roci.dev/diff-server/util/time"
 )
 
@@ -59,7 +58,7 @@ func TestInject(t *testing.T) {
 		req := httptest.NewRequest(t.method, "/inject", strings.NewReader(t.req))
 		req.Header.Set("Content-type", "application/json")
 		resp := httptest.NewRecorder()
-		s.inject(resp, req, log.Default())
+		s.inject(resp, req)
 
 		body := bytes.Buffer{}
 		_, err := io.Copy(&body, resp.Result().Body)

--- a/serve/middleware.go
+++ b/serve/middleware.go
@@ -1,0 +1,73 @@
+package serve
+
+import (
+	"context"
+	"net/http"
+	"sync/atomic"
+
+	zl "github.com/rs/zerolog"
+	"roci.dev/diff-server/util/log"
+	"roci.dev/diff-server/util/loghttp"
+)
+
+// contectLogger is http middleware that inserts a contextual logger into
+// the http.Request's Context.
+func contextLogger(next http.Handler) http.Handler {
+	return &contextLoggerHandler{next: next}
+}
+
+type contextLoggerHandler struct {
+	next  http.Handler
+	reqID uint64
+}
+
+func (c *contextLoggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	lc := log.Default().With().Str("req", r.URL.String()).Uint64("rid", atomic.AddUint64(&c.reqID, 1))
+	syncID := r.Header.Get("X-Replicache-SyncID")
+	if syncID != "" {
+		lc = lc.Str("syncID", syncID)
+	}
+	l := lc.Logger()
+	ctx := context.WithValue(r.Context(), loggerKey{}, l)
+	r = r.WithContext(ctx)
+	c.next.ServeHTTP(w, r)
+}
+
+type loggerKey struct{}
+
+func logger(r *http.Request) zl.Logger {
+	i := r.Context().Value(loggerKey{})
+	if i != nil {
+		l, ok := i.(zl.Logger)
+		if ok {
+			return l
+		}
+	}
+	l := log.Default()
+	l.Info().Msg("zlogger missing from request context (this is expected in unit tests)")
+	return l
+}
+
+// panicCatcher is http middleware that recovers from panics, logs them, and
+// turns them into 500s.
+func panicCatcher(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		l := logger(r)
+		defer func() {
+			err := recover()
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				l.Error().Msgf("Handler panicked: %#v", err)
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
+}
+
+// logHTTP is http middleware that dumps HTTP requests and responses via loghttp.
+func logHTTP(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handler := loghttp.Wrap(next, logger(r))
+		handler.ServeHTTP(w, r)
+	})
+}

--- a/serve/pull_test.go
+++ b/serve/pull_test.go
@@ -16,7 +16,6 @@ import (
 	"roci.dev/diff-server/db"
 	"roci.dev/diff-server/kv"
 	servetypes "roci.dev/diff-server/serve/types"
-	"roci.dev/diff-server/util/log"
 	"roci.dev/diff-server/util/time"
 )
 
@@ -254,7 +253,7 @@ func TestAPI(t *testing.T) {
 		}
 		req.Header.Set("X-Replicache-SyncID", "syncID")
 		resp := httptest.NewRecorder()
-		s.pull(resp, req, log.Default())
+		s.pull(resp, req)
 
 		body := bytes.Buffer{}
 		_, err = io.Copy(&body, resp.Result().Body)

--- a/serve/service_test.go
+++ b/serve/service_test.go
@@ -42,23 +42,15 @@ func TestConcurrentAccessUsingMultipleServices(t *testing.T) {
 	req2.Header.Add("Authorization", "sandbox")
 	req3 := httptest.NewRequest("POST", "/pull", strings.NewReader(`{"baseStateID": "00000000000000000000000000000000", "checksum": "00000000", "clientID": "clientid"}`))
 	req3.Header.Add("Authorization", "sandbox")
-	svc1.ServeHTTP(res[0], req1)
-	svc2.ServeHTTP(res[1], req2)
-	svc1.ServeHTTP(res[2], req3)
+	mux1 := http.NewServeMux()
+	RegisterHandlers(svc1, mux1)
+	mux1.ServeHTTP(res[0], req1)
+	mux2 := http.NewServeMux()
+	RegisterHandlers(svc2, mux2)
+	mux2.ServeHTTP(res[1], req2)
+	mux1.ServeHTTP(res[2], req3)
 
 	for i, r := range res {
 		assert.Equal(http.StatusOK, r.Code, fmt.Sprintf("response %d: %s", i, string(r.Body.Bytes())))
 	}
-}
-
-func TestNo301(t *testing.T) {
-	assert := assert.New(t)
-	td, _ := ioutil.TempDir("", "")
-
-	svc := NewService(td, getAccounts(), "", nil, true)
-	r := httptest.NewRecorder()
-
-	svc.ServeHTTP(r, httptest.NewRequest("POST", "//pull", strings.NewReader(`{"accountID": "sandbox", "baseStateID": "00000000000000000000000000000000", "checksum": "00000000", "clientID": "clientid"}`)))
-	assert.Equal(http.StatusNotFound, r.Code)
-	assert.Equal("not found", string(r.Body.Bytes()))
 }


### PR DESCRIPTION
- move request logging, context logging, etc to a middleware pattern
- use an http servermux instead of our own
- when not running on zeit instantiate a server that has default timeouts (the default is no timeout)