### PR TITLE
clean up logging logic

### DIFF
--- a/db/diff_test.go
+++ b/db/diff_test.go
@@ -196,8 +196,18 @@ func TestDiff(t *testing.T) {
 				r := db.Noms().WriteValue(types.String("not a commit"))
 				fromID = r.TargetHash()
 			},
-			nil,
-			"Invalid baseStateID",
+			[]kv.Operation{
+				{
+					Op:   kv.OpRemove,
+					Path: "/",
+				},
+				{
+					Op:    kv.OpAdd,
+					Path:  "/foo",
+					Value: []byte("\"bar\""),
+				},
+			},
+			"",
 		},
 	}
 

--- a/serve/pull.go
+++ b/serve/pull.go
@@ -106,22 +106,22 @@ func (s *Service) pull(rw http.ResponseWriter, r *http.Request) {
 		serverError(rw, err, l)
 		return
 	}
+	// Add a newline to make output to console etc nicer.
+	resp = append(resp, byte('\n'))
 	rw.Header().Set("Content-type", "application/json")
 	rw.Header().Set("Entity-length", strconv.Itoa(len(resp)))
 
 	w := io.Writer(rw)
 	if strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
 		rw.Header().Set("Content-encoding", "gzip")
-		w = gzip.NewWriter(w)
+		gzw := gzip.NewWriter(rw)
+		defer gzw.Close()
+		w = gzw
 	}
-
 	_, err = io.Copy(w, bytes.NewReader(resp))
 	if err != nil {
 		serverError(rw, err, l)
-	}
-	w.Write([]byte{'\n'})
-	if c, ok := w.(io.Closer); ok {
-		c.Close()
+		return
 	}
 }
 

--- a/util/loghttp/loghttp_test.go
+++ b/util/loghttp/loghttp_test.go
@@ -27,6 +27,10 @@ func Test_maybeUnzip(t *testing.T) {
 			[]byte{},
 		},
 		{
+			[]byte("\n"),
+			[]byte("\n"),
+		},
+		{
 			[]byte("not gzipped"),
 			[]byte("not gzipped"),
 		},


### PR DESCRIPTION
- continue to log if even if we fail to unzip the response
- clean up response closer and header logic in pull
- stop logging errors for things that are not errors in pull
- clean up messaging around full sync