### PR TITLE
Use JSON Patch compatible clear

### DIFF
--- a/db/diff.go
+++ b/db/diff.go
@@ -12,16 +12,26 @@ import (
 	"roci.dev/diff-server/kv"
 )
 
-func fullSync(db *DB, from hash.Hash, l zl.Logger) ([]kv.Operation, Commit) {
+func fullSync(version uint32, db *DB, from hash.Hash, l zl.Logger) ([]kv.Operation, Commit) {
 	l.Debug().Msgf("Requested sync %s basis could not be found - sending a full sync", from.String())
-	r := []kv.Operation{
-		kv.Operation{
+
+	var op kv.Operation
+	if version < 2 {
+		op = kv.Operation{
 			Op:   kv.OpRemove,
 			Path: "/",
-		},
+		}
+	} else {
+		op =
+			kv.Operation{
+				Op:          kv.OpReplace,
+				Path:        "",
+				ValueString: "{}",
+			}
+
 	}
 	m := kv.NewMap(db.Noms())
-	return r, makeCommit(db.Noms(), types.Ref{}, datetime.Epoch, db.ds.Database().WriteValue(m.NomsMap()), m.NomsChecksum(), 0 /*lastMutationID*/)
+	return []kv.Operation{op}, makeCommit(db.Noms(), types.Ref{}, datetime.Epoch, db.ds.Database().WriteValue(m.NomsMap()), m.NomsChecksum(), 0 /*lastMutationID*/)
 }
 
 func maybeDecodeCommit(v types.Value, h hash.Hash, expectedChecksum kv.Checksum, l zl.Logger) (Commit, error) {
@@ -48,13 +58,13 @@ func (db *DB) Diff(version uint32, fromHash hash.Hash, fromChecksum kv.Checksum,
 	if v == nil {
 		// Unknown basis is not an error: maybe it's really old or we're starting up cold.
 		l.Info().Msgf("Sending full sync: unknown basis %s", fromHash)
-		r, fc = fullSync(db, fromHash, l)
+		r, fc = fullSync(version, db, fromHash, l)
 	} else {
 		fc, err = maybeDecodeCommit(v, fromHash, fromChecksum, l)
 		if err != nil {
 			// Inability to decode a Commit or getting the wrong checksum is an error.
 			l.Error().Msgf("Sending full sync: cannot diff from basis %s: %s", fromHash, err)
-			r, fc = fullSync(db, fromHash, l)
+			r, fc = fullSync(version, db, fromHash, l)
 		}
 	}
 

--- a/db/diff_test.go
+++ b/db/diff_test.go
@@ -453,3 +453,229 @@ func TestDiffV1(t *testing.T) {
 		}
 	}
 }
+
+func TestDiffV2(t *testing.T) {
+	assert := assert.New(t)
+	db, dir := LoadTempDB(assert)
+	fmt.Println(dir)
+
+	var fromID hash.Hash
+	var fromChecksum string
+	tc := []struct {
+		label         string
+		f             func()
+		expectedDiff  []kv.Operation
+		expectedError string
+	}{
+		{
+			"same-commit",
+			func() {},
+			[]kv.Operation{},
+			"",
+		},
+		{
+			"change-1",
+			func() {
+				m := kv.NewMapForTest(db.Noms(), "foo", `"bar"`, "hot", `"dog"`)
+				c, err := db.MaybePutData(m, 0 /*lastMutationID*/)
+				assert.False(c.NomsStruct.IsZeroValue())
+				assert.NoError(err)
+			},
+			[]kv.Operation{
+				{
+					Op:          kv.OpAdd,
+					Path:        "/foo",
+					ValueString: "\"bar\"",
+				},
+				{
+					Op:          kv.OpAdd,
+					Path:        "/hot",
+					ValueString: "\"dog\"",
+				},
+			},
+			"",
+		},
+		{
+			"change-2",
+			func() {
+				m := kv.NewMapForTest(db.Noms(), "foo", `"baz"`, "mon", `"key"`)
+				c, err := db.MaybePutData(m, 0 /*lastMutationID*/)
+				assert.False(c.NomsStruct.IsZeroValue())
+				assert.NoError(err)
+			},
+			[]kv.Operation{
+				{
+					Op:          kv.OpReplace,
+					Path:        "/foo",
+					ValueString: "\"baz\"",
+				},
+				{
+					Op:   kv.OpRemove,
+					Path: "/hot",
+				},
+				{
+					Op:          kv.OpAdd,
+					Path:        "/mon",
+					ValueString: "\"key\"",
+				},
+			},
+			"",
+		},
+		{
+			"no-diff",
+			func() {},
+			[]kv.Operation{},
+			"",
+		},
+		{
+			"fresh-non-existing-commit",
+			func() {
+				db, dir = LoadTempDB(assert)
+				fmt.Println("newdir", dir)
+				me := kv.NewMapForTest(db.Noms()).Edit()
+				for _, s := range []string{"a", "b", "c"} {
+					assert.NoError(me.Set(types.String(s), types.String(s)))
+				}
+				m := me.Build()
+				c, err := db.MaybePutData(m, 0 /*lastMutationID*/)
+				assert.False(c.NomsStruct.IsZeroValue())
+				assert.NoError(err)
+			},
+			[]kv.Operation{
+				kv.Operation{
+					Op:          kv.OpReplace,
+					Path:        "",
+					ValueString: "{}",
+				},
+				kv.Operation{
+					Op:          kv.OpAdd,
+					Path:        "/a",
+					ValueString: `"a"`,
+				},
+				kv.Operation{
+					Op:          kv.OpAdd,
+					Path:        "/b",
+					ValueString: `"b"`,
+				},
+				kv.Operation{
+					Op:          kv.OpAdd,
+					Path:        "/c",
+					ValueString: `"c"`,
+				},
+			},
+			"",
+		},
+		{
+			"fresh-empty-commit",
+			func() {
+				fromID = hash.Hash{}
+			},
+			[]kv.Operation{
+				kv.Operation{
+					Op:          kv.OpReplace,
+					Path:        "",
+					ValueString: "{}",
+				},
+				kv.Operation{
+					Op:          kv.OpAdd,
+					Path:        "/a",
+					ValueString: `"a"`,
+				},
+				kv.Operation{
+					Op:          kv.OpAdd,
+					Path:        "/b",
+					ValueString: `"b"`,
+				},
+				kv.Operation{
+					Op:          kv.OpAdd,
+					Path:        "/c",
+					ValueString: `"c"`,
+				},
+			},
+			"",
+		},
+		{
+			"invalid-checksum",
+			func() {
+				m := kv.NewMapForTest(db.Noms(), "foo", `"bar"`)
+				c, err := db.MaybePutData(m, 0 /*lastMutationID*/)
+				assert.False(c.NomsStruct.IsZeroValue())
+				assert.NoError(err)
+				fromChecksum = "00000000"
+			},
+			[]kv.Operation{
+				{
+					Op:          kv.OpReplace,
+					Path:        "",
+					ValueString: "{}",
+				},
+				{
+					Op:          kv.OpAdd,
+					Path:        "/foo",
+					ValueString: "\"bar\"",
+				},
+			},
+			"",
+		},
+		{
+			"same-commit-invalid-checksum",
+			func() {
+				fromChecksum = "00000000"
+			},
+			[]kv.Operation{
+				{
+					Op:          kv.OpReplace,
+					Path:        "",
+					ValueString: "{}",
+				},
+				{
+					Op:          kv.OpAdd,
+					Path:        "/foo",
+					ValueString: "\"bar\"",
+				},
+			},
+			"",
+		},
+		{
+			"invalid-commit-id",
+			func() {
+				r := db.Noms().WriteValue(types.String("not a commit"))
+				fromID = r.TargetHash()
+			},
+			[]kv.Operation{
+				{
+					Op:          kv.OpReplace,
+					Path:        "",
+					ValueString: "{}",
+				},
+				{
+					Op:          kv.OpAdd,
+					Path:        "/foo",
+					ValueString: "\"bar\"",
+				},
+			},
+			"",
+		},
+	}
+
+	for _, t := range tc {
+		fromID = db.Head().NomsStruct.Hash()
+		var err error
+		fromChecksum = string(db.Head().Value.Checksum)
+		t.f()
+		c, err := kv.ChecksumFromString(fromChecksum)
+		assert.NoError(err)
+		r, err := db.Diff(2, fromID, *c, db.Head(), log.Default())
+		if t.expectedError == "" {
+			assert.NoError(err, t.label)
+			expected, err := json.Marshal(t.expectedDiff)
+			assert.NoError(err, t.label)
+			actual, err := json.Marshal(r)
+			assert.NoError(err, t.label)
+			assert.Equal(string(expected), string(actual), t.label)
+		} else {
+			assert.Nil(r, t.label)
+			assert.EqualError(err, t.expectedError, t.label)
+		}
+	}
+}

--- a/kv/map.go
+++ b/kv/map.go
@@ -2,7 +2,6 @@ package kv
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 
 	"roci.dev/diff-server/util/chk"
@@ -98,9 +97,6 @@ func (me *MapEditor) Get(key types.Value) types.Value {
 // be parsed from canonical json, otherwise we might parse two different
 // values for the same canonical json.
 func (me *MapEditor) Set(key types.String, value types.Value) error {
-	if key == "" {
-		return errors.New("key must be non-empty")
-	}
 	if me.MapEditor.Has(key) {
 		// Have to do this in order to properly update checksum.
 		if err := me.Remove(key); err != nil {

--- a/kv/map_test.go
+++ b/kv/map_test.go
@@ -3,6 +3,7 @@ package kv_test
 import (
 	"testing"
 
+	"github.com/attic-labs/noms/go/nomdl"
 	"github.com/attic-labs/noms/go/types"
 	"github.com/stretchr/testify/assert"
 	"roci.dev/diff-server/kv"
@@ -108,7 +109,11 @@ func TestEmptyKey(t *testing.T) {
 	assert := assert.New(t)
 	noms := memstore.New()
 	me := kv.NewMap(noms).Edit()
-	assert.Error(me.Set(s(""), types.Bool(true)), "key must be non-empty")
+	assert.NoError(me.Set(s(""), types.Bool(true)))
+	m := me.Build()
+	expected := nomdl.MustParse(noms, "map {\"\": true}").(types.Map)
+	assert.Equal(types.EncodedValue(m.NomsMap()),
+		types.EncodedValue(expected))
 }
 
 func TestEmpty(t *testing.T) {

--- a/kv/patch.go
+++ b/kv/patch.go
@@ -123,13 +123,21 @@ func Diff(version uint32, from, to Map, r []Operation) ([]Operation, error) {
 	return r, nil
 }
 
-// ApplyPath applies the given series of ops to the input Map.
+// ApplyPatch applies the given series of ops to the input Map.
 func ApplyPatch(version uint32, vrw types.ValueReadWriter, to Map, patch []Operation) (Map, error) {
 	if len(patch) == 0 {
 		return to, nil
 	}
 	ed := to.Edit()
 	for _, op := range patch {
+		if version >= 2 &&
+			op.Path == "" && op.Op == OpReplace && op.ValueString == "{}" {
+			// Clear map
+			emptyMap := NewMap(ed.noms)
+			ed = emptyMap.Edit()
+			continue
+		}
+
 		if !strings.HasPrefix(op.Path, "/") {
 			return Map{}, fmt.Errorf("Invalid path %s - must start with /", op.Path)
 		}

--- a/serve/pull_test.go
+++ b/serve/pull_test.go
@@ -19,6 +19,284 @@ import (
 	"roci.dev/diff-server/util/time"
 )
 
+func TestAPIV2(t *testing.T) {
+	assert := assert.New(t)
+	defer time.SetFake()()
+
+	tc := []struct {
+		pullMethod  string
+		pullReq     string
+		authHeader  string
+		accountCV   string
+		overrideCV  string
+		expCVAuth   string
+		CVResponse  servetypes.ClientViewResponse
+		CVCode      int
+		CVErr       error
+		expPullResp string
+		expPullErr  string
+	}{
+		// Unsupported method
+		{"GET",
+			`{"baseStateID": "00000000000000000000000000000000", "checksum": "00000000", "clientID": "clientid", "version": 2}`,
+			"accountID",
+			"",
+			"",
+			"",
+			servetypes.ClientViewResponse{},
+			0,
+			nil,
+			``,
+			"Unsupported method: GET"},
+		// Supports OPTIONS for cors headers
+		{"OPTIONS",
+			``,
+			"accountID",
+			"",
+			"",
+			"",
+			servetypes.ClientViewResponse{},
+			0,
+			nil,
+			``,
+			""},
+		// No client view to fetch from.
+		{"POST",
+			`{"baseStateID": "00000000000000000000000000000000", "checksum": "00000000", "clientID": "clientid", "version": 2}`,
+			"accountID",
+			"",
+			"",
+			"",
+			servetypes.ClientViewResponse{},
+			0,
+			nil,
+			`{"stateID":"s3n5j759kirvvs3fqeott07a43lk41ud","lastMutationID":1,"patch":[{"op":"replace","path":"","valueString":"{}"},{"op":"add","path":"/foo","valueString":"\"bar\""}],"checksum":"c4e7090d","clientViewInfo":{"httpStatusCode":0,"errorMessage":""}}`,
+			""},
+
+		// Successful client view fetch.
+		{"POST",
+			`{"baseStateID": "00000000000000000000000000000000", "checksum": "00000000", "clientID": "clientid", "clientViewAuth": "clientauth", "version": 2}`,
+			"accountID",
+			"cv",
+			"",
+			"clientauth",
+			servetypes.ClientViewResponse{ClientView: map[string]json.RawMessage{"new": b(`"value"`)}, LastMutationID: 2},
+			200,
+			nil,
+			`{"stateID":"hoc705ifecv1c858qgbqr9jghh4d9l96","lastMutationID":2,"patch":[{"op":"replace","path":"","valueString":"{}"},{"op":"add","path":"/new","valueString":"\"value\""}],"checksum":"f9ef007b","clientViewInfo":{"httpStatusCode":200,"errorMessage":""}}`,
+			""},
+		// Successful client view fetch via override.
+		{"POST",
+			`{"baseStateID": "00000000000000000000000000000000", "checksum": "00000000", "clientID": "clientid", "clientViewAuth": "clientauth", "version": 2}`,
+			"accountID",
+			"",
+			"override",
+			"clientauth",
+			servetypes.ClientViewResponse{ClientView: map[string]json.RawMessage{"new": b(`"value"`)}, LastMutationID: 2},
+			200,
+			nil,
+			`{"stateID":"hoc705ifecv1c858qgbqr9jghh4d9l96","lastMutationID":2,"patch":[{"op":"replace","path":"","valueString":"{}"},{"op":"add","path":"/new","valueString":"\"value\""}],"checksum":"f9ef007b","clientViewInfo":{"httpStatusCode":200,"errorMessage":""}}`,
+			""},
+
+		// Successful client view fetch via override (with override).
+		{"POST",
+			`{"baseStateID": "00000000000000000000000000000000", "checksum": "00000000", "clientID": "clientid", "clientViewAuth": "clientauth", "version": 2}`,
+			"accountID",
+			"cv",
+			"override",
+			"clientauth",
+			servetypes.ClientViewResponse{ClientView: map[string]json.RawMessage{"new": b(`"value"`)}, LastMutationID: 2},
+			200,
+			nil,
+			`{"stateID":"hoc705ifecv1c858qgbqr9jghh4d9l96","lastMutationID":2,"patch":[{"op":"replace","path":"","valueString":"{}"},{"op":"add","path":"/new","valueString":"\"value\""}],"checksum":"f9ef007b","clientViewInfo":{"httpStatusCode":200,"errorMessage":""}}`,
+			""},
+
+		// Successful nop client view fetch where lastMutationID does not change.
+		{"POST",
+			`{"baseStateID": "s3n5j759kirvvs3fqeott07a43lk41ud", "checksum": "c4e7090d", "clientID": "clientid", "clientViewAuth": "clientauth", "version": 2}`,
+			"accountID",
+			"cv",
+			"",
+			"clientauth",
+			servetypes.ClientViewResponse{ClientView: map[string]json.RawMessage{"foo": b(`"bar"`)}, LastMutationID: 1},
+			200,
+			nil,
+			`{"stateID":"s3n5j759kirvvs3fqeott07a43lk41ud","lastMutationID":1,"patch":[],"checksum":"c4e7090d","clientViewInfo":{"httpStatusCode":200,"errorMessage":""}}`,
+			""},
+
+		// Successful nop client view fetch where lastMutationID does change.
+		{"POST",
+			`{"baseStateID": "s3n5j759kirvvs3fqeott07a43lk41ud", "checksum": "c4e7090d", "clientID": "clientid", "clientViewAuth": "clientauth", "version": 2}`,
+			"accountID",
+			"cv",
+			"",
+			"clientauth",
+			servetypes.ClientViewResponse{ClientView: map[string]json.RawMessage{"foo": b(`"bar"`)}, LastMutationID: 77},
+			200,
+			nil,
+			`{"stateID":"pi99ftvp6nchoej3i58flsqm8enqg4vd","lastMutationID":77,"patch":[],"checksum":"c4e7090d","clientViewInfo":{"httpStatusCode":200,"errorMessage":""}}`,
+			""},
+
+		// Fetch errors out.
+		{"POST",
+			`{"baseStateID": "00000000000000000000000000000000", "checksum": "00000000", "clientID": "clientid", "clientViewAuth": "clientauth", "version": 2}`,
+			"accountID",
+			"cv",
+			"",
+			"clientauth",
+			servetypes.ClientViewResponse{ClientView: map[string]json.RawMessage{"new": b(`"value"`)}, LastMutationID: 2},
+			200,
+			errors.New("boom"),
+			`{"stateID":"s3n5j759kirvvs3fqeott07a43lk41ud","lastMutationID":1,"patch":[{"op":"replace","path":"","valueString":"{}"},{"op":"add","path":"/foo","valueString":"\"bar\""}],"checksum":"c4e7090d","clientViewInfo":{"httpStatusCode":200,"errorMessage":""}}`,
+			""},
+
+		// No Authorization header.
+		{"POST",
+			`{"baseStateID": "00000000000000000000000000000000", "checksum": "00000000", "clientID": "clientid", "clientViewAuth": "clientauth", "version": 2}`,
+			"",
+			"",
+			"",
+			"",
+			servetypes.ClientViewResponse{},
+			0,
+			nil,
+			``,
+			"Missing Authorization"},
+
+		// Unknown account passed in Authorization header.
+		{"POST",
+			`{"baseStateID": "00000000000000000000000000000000", "checksum": "00000000", "clientID": "clientid", "clientViewAuth": "clientauth", "version": 2}`,
+			"BONK",
+			"",
+			"",
+			"",
+			servetypes.ClientViewResponse{},
+			0,
+			nil,
+			``,
+			"Unknown account"},
+
+		// No clientID passed in.
+		{"POST",
+			`{"baseStateID": "00000000000000000000000000000000", "checksum": "00000000", "clientViewAuth": "clientauth", "version": 2}`,
+			"accountID",
+			"",
+			"",
+			"",
+			servetypes.ClientViewResponse{},
+			0,
+			nil,
+			``,
+			"Missing clientID"},
+
+		// Invalid baseStateID.
+		{"POST",
+			`{"baseStateID": "beep", "checksum": "00000000", "clientID": "clientid", "clientViewAuth": "clientauth", "version": 2}`,
+			"accountID",
+			"",
+			"",
+			"",
+			servetypes.ClientViewResponse{},
+			0,
+			nil,
+			``,
+			"Invalid baseStateID"},
+
+		// No baseStateID is fine (first pull).
+		{"POST",
+			`{"baseStateID": "", "checksum": "00000000", "clientID": "clientid", "clientViewAuth": "clientauth", "version": 2}`,
+			"accountID",
+			"cv",
+			"",
+			"clientauth",
+			servetypes.ClientViewResponse{ClientView: map[string]json.RawMessage{"new": b(`"value"`)}, LastMutationID: 2},
+			200,
+			nil,
+			`{"stateID":"hoc705ifecv1c858qgbqr9jghh4d9l96","lastMutationID":2,"patch":[{"op":"replace","path":"","valueString":"{}"},{"op":"add","path":"/new","valueString":"\"value\""}],"checksum":"f9ef007b","clientViewInfo":{"httpStatusCode":200,"errorMessage":""}}`,
+			""},
+
+		// Invalid checksum.
+		{"POST",
+			`{"baseStateID": "00000000000000000000000000000000", "checksum": "not", "clientID": "clientid", "clientViewAuth": "clientauth", "version": 2}`,
+			"accountID",
+			"",
+			"",
+			"",
+			servetypes.ClientViewResponse{},
+			0,
+			nil,
+			``,
+			"Invalid checksum"},
+
+		// Ensure it canonicalizes the client view JSON.
+		{"POST",
+			`{"baseStateID": "00000000000000000000000000000000", "checksum": "00000000", "clientID": "clientid", "clientViewAuth": "clientauth", "version": 2}`,
+			"accountID",
+			"cv",
+			"",
+			"clientauth",
+			servetypes.ClientViewResponse{ClientView: map[string]json.RawMessage{"new": b(`"\u000b"`)}, LastMutationID: 2}, // "\u000B" is canonical
+			200,
+			nil,
+			`{"stateID":"qv7hd0v4i49utb1gjs2hiefh1vfhjegk","lastMutationID":2,"patch":[{"op":"replace","path":"","valueString":"{}"},{"op":"add","path":"/new","valueString":"\"\\u000B\""}],"checksum":"b2dc0d6a","clientViewInfo":{"httpStatusCode":200,"errorMessage":""}}`,
+			""},
+	}
+
+	for i, t := range tc {
+		fcvg := &fakeClientViewGet{resp: t.CVResponse, code: t.CVCode, err: t.CVErr}
+		td, _ := ioutil.TempDir("", "")
+		s := NewService(td, []Account{Account{ID: "accountID", Name: "accountID", Pubkey: nil, ClientViewURL: t.accountCV}}, t.overrideCV, fcvg, true)
+		noms, err := s.getNoms("accountID")
+		assert.NoError(err)
+		db, err := db.New(noms.GetDataset("client/clientid"))
+		assert.NoError(err)
+		m := kv.NewMapForTest(noms, "foo", `"bar"`)
+		c, err := db.MaybePutData(m, 1 /*lastMutationID*/)
+		assert.NoError(err)
+		assert.False(c.NomsStruct.IsZeroValue())
+
+		msg := fmt.Sprintf("test case %d: %s", i, t.pullReq)
+		req := httptest.NewRequest(t.pullMethod, "/sync", strings.NewReader(t.pullReq))
+		req.Header.Set("Content-type", "application/json")
+		if t.authHeader != "" {
+			req.Header.Set("Authorization", t.authHeader)
+		}
+		req.Header.Set("X-Replicache-SyncID", "syncID")
+		resp := httptest.NewRecorder()
+		s.pull(resp, req)
+
+		body := bytes.Buffer{}
+		_, err = io.Copy(&body, resp.Result().Body)
+		assert.NoError(err, msg)
+		if t.expPullErr == "" {
+			assert.True(len(resp.Result().Header.Get("Access-Control-Allow-Origin")) > 0)
+			assert.True(len(resp.Result().Header.Get("Access-Control-Allow-Methods")) > 0)
+			assert.True(len(resp.Result().Header.Get("Access-Control-Allow-Headers")) > 0)
+			if t.pullMethod == "OPTIONS" {
+				assert.Equal(200, resp.Result().StatusCode)
+				continue
+			}
+			assert.Equal("application/json", resp.Result().Header.Get("Content-type"))
+			assert.Equal(t.expPullResp+"\n", string(body.Bytes()), msg)
+		} else {
+			assert.Regexp(t.expPullErr, string(body.Bytes()), msg)
+		}
+		expectedCVURL := ""
+		if t.overrideCV != "" {
+			expectedCVURL = t.overrideCV
+		} else if t.accountCV != "" {
+			expectedCVURL = t.accountCV
+		}
+		if expectedCVURL != "" {
+			assert.True(fcvg.called, msg)
+			assert.Equal(expectedCVURL, fcvg.gotURL, msg)
+			assert.Equal(t.expCVAuth, fcvg.gotAuth, msg)
+			assert.Equal("clientid", fcvg.gotClientID)
+			assert.Equal("syncID", fcvg.gotSyncID)
+		}
+	}
+}
+
 func TestAPIV1(t *testing.T) {
 	assert := assert.New(t)
 	defer time.SetFake()()


### PR DESCRIPTION
When clearing the map we now send
`{"op":"replace","path":"","value":{}}` instead of
`{"op":"remove","path":"/"}` which really should mean remove the key
`""`/

Towards https://github.com/rocicorp/repc/issues/124