### PR TITLE
initial implementation of signup

### DIFF
--- a/account/db.go
+++ b/account/db.go
@@ -1,0 +1,150 @@
+// Package account is a lightweight account system for Replicache customers.
+package account
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/attic-labs/noms/go/datas"
+	"github.com/attic-labs/noms/go/marshal"
+	"github.com/attic-labs/noms/go/types"
+)
+
+// DB represents the Replicache account database. It is modeled on the pattern
+// established by the main db (db/db.go).
+type DB struct {
+	ds datas.Dataset
+
+	mu   sync.Mutex
+	head Commit
+}
+
+// Commit is the git-like commit structure noms uses to store values.
+// The account database keeps a single Commit at the head of its dataset
+// as opposed to a chain of Commits representing changes. Noms requires
+// a Commit structure like this.
+type Commit struct {
+	// Parents and Meta are unused.
+	Parents []types.Ref `noms:",set"`
+	Meta    struct {
+	}
+
+	Value Accounts
+}
+
+// Account records.
+type Accounts struct {
+	NextASID   uint32
+	AutoSignup map[uint32]ASAccount // Map key is the ASID.
+}
+
+// An individual AutoSignup account record.
+type ASAccount struct {
+	ASID        uint32
+	Name        string
+	Email       string
+	DateCreated string
+}
+
+func NewDB(ds datas.Dataset) (*DB, error) {
+	r := DB{
+		ds: ds,
+	}
+	defer r.lock()()
+	err := r.initLocked()
+	if err != nil {
+		return nil, err
+	}
+
+	return &r, nil
+}
+
+// ASIDs are issued in a separate range from regular accounts. See RFC.
+const LowestASID uint32 = 1000000
+
+func (db *DB) initLocked() error {
+	if !db.ds.HasHead() {
+		accounts := Accounts{
+			NextASID:   LowestASID,
+			AutoSignup: make(map[uint32]ASAccount),
+		}
+		return db.setHeadLocked(Commit{Value: accounts})
+	}
+
+	var head Commit
+	err := marshal.Unmarshal(db.ds.Head(), &head)
+	if err != nil {
+		return err
+	}
+	// Noms roundtrips empty maps as nil, so ensure we have a map.
+	if head.Value.AutoSignup == nil {
+		head.Value.AutoSignup = make(map[uint32]ASAccount)
+	}
+
+	db.head = head
+	return nil
+}
+
+func (db *DB) Noms() datas.Database {
+	return db.ds.Database()
+}
+
+// Callers don't care about the underlying Commit structure, so we have
+// HeadValue and SetHeadWithValue, unlike db/db.go, which has Head and SetHead.
+func (db *DB) HeadValue() Accounts {
+	defer db.lock()()
+	return db.head.Value
+}
+
+// SetHeadWithValue creates a new Commit with accounts as its value and sets head to it.
+// If setHead returns a RetryError, caller should reload head, re-apply changes, and
+// try again (up to a few times).
+func (db *DB) SetHeadWithValue(accounts Accounts) error {
+	defer db.lock()()
+	return db.setHeadLocked(Commit{Value: accounts})
+}
+
+func (db *DB) setHeadLocked(newHead Commit) error {
+	v, err := marshal.Marshal(db.Noms(), newHead)
+	if err != nil {
+		return err
+	}
+	ref := db.Noms().WriteValue(v)
+	var ds datas.Dataset
+	if ds, err = db.Noms().SetHead(db.ds, ref); err != nil {
+		// We could save the caller a reload of head in this case by returning
+		// the new ds on error. It kinda complicates the caller tho, so didn't do it.
+		return RetryError{err}
+	}
+	db.ds = ds
+	db.head = newHead
+	return nil
+}
+
+// RetryError indicates someone set head out from under us and the operation
+// should be retried (re-load the new head, re-apply the changes, and attempt to
+// set head again).
+type RetryError struct {
+	wrapped error
+}
+
+func (e RetryError) Error() string {
+	return fmt.Sprintf("RetryError: %v", e.wrapped)
+}
+
+func (e *RetryError) Unwrap() error { return e.wrapped }
+
+// Reload reloads the latest state from the underlying noms db.
+func (db *DB) Reload() error {
+	db.lock()()
+	db.ds.Database().Rebase()
+	db.ds = db.ds.Database().GetDataset(db.ds.ID())
+	return db.initLocked()
+}
+
+func (db *DB) lock() func() {
+	db.mu.Lock()
+	return func() {
+		db.mu.Unlock()
+	}
+}

--- a/account/db_test.go
+++ b/account/db_test.go
@@ -1,0 +1,84 @@
+package account_test
+
+import (
+	"errors"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"roci.dev/diff-server/account"
+)
+
+func TestInit(t *testing.T) {
+	assert := assert.New(t)
+	db, dir := account.LoadTempDB(assert)
+	defer func() { assert.NoError(os.RemoveAll(dir)) }()
+
+	assert.Equal(account.LowestASID, db.HeadValue().NextASID)
+	assert.Equal(0, len(db.HeadValue().AutoSignup))
+}
+
+func TestReload(t *testing.T) {
+	assert := assert.New(t)
+	db, dir := account.LoadTempDB(assert)
+	defer func() { assert.NoError(os.RemoveAll(dir)) }()
+
+	// Use db2 to change head behind db's back.
+	db2 := account.LoadTempDBWithPath(assert, dir)
+	accounts := db2.HeadValue()
+	accounts.NextASID = 2
+	accounts.AutoSignup[2] = account.ASAccount{ASID: 2}
+	assert.NoError(db2.SetHeadWithValue(accounts))
+
+	// Now ensure that if we reload db we see the changes from db2.
+	assert.NoError(db.Reload())
+	assert.Equal(uint32(2), db.HeadValue().NextASID)
+	_, exists := db.HeadValue().AutoSignup[2]
+	assert.True(exists)
+}
+
+func TestSetHead(t *testing.T) {
+	assert := assert.New(t)
+	db, dir := account.LoadTempDB(assert)
+	defer func() { assert.NoError(os.RemoveAll(dir)) }()
+
+	accounts := db.HeadValue()
+	accounts.NextASID = 123
+	accounts.AutoSignup[123] = account.ASAccount{ASID: 123}
+	assert.NoError(db.SetHeadWithValue(accounts))
+
+	gotDB := account.LoadTempDBWithPath(assert, dir)
+	assert.Equal(accounts, gotDB.HeadValue())
+}
+
+func TestConcurrentSetHead(t *testing.T) {
+	assert := assert.New(t)
+	db, dir := account.LoadTempDB(assert)
+	defer func() { assert.NoError(os.RemoveAll(dir)) }()
+
+	// Set head behind db's back.
+	var wg sync.WaitGroup
+	var err error
+	wg.Add(1)
+	go func() {
+		otherDB := account.LoadTempDBWithPath(assert, dir)
+		accounts := otherDB.HeadValue()
+		accounts.NextASID = 1
+		accounts.AutoSignup[1] = account.ASAccount{ASID: 1}
+		err = otherDB.SetHeadWithValue(accounts)
+		wg.Done()
+	}()
+	wg.Wait()
+	assert.NoError(err)
+
+	// Head has been set behind our back so we expect to get a RetryError
+	// when we try to set head.
+	accounts := db.HeadValue()
+	accounts.NextASID = 2
+	accounts.AutoSignup[2] = account.ASAccount{ASID: 2}
+	err = db.SetHeadWithValue(accounts)
+	assert.Error(err)
+	var retryError account.RetryError
+	assert.True(errors.As(err, &retryError))
+}

--- a/account/tempdb.go
+++ b/account/tempdb.go
@@ -1,0 +1,27 @@
+package account
+
+import (
+	"io/ioutil"
+
+	"github.com/attic-labs/noms/go/spec"
+	"github.com/stretchr/testify/assert"
+)
+
+func LoadTempDB(assert *assert.Assertions) (r *DB, dir string) {
+	td, err := ioutil.TempDir("", "")
+	assert.NoError(err)
+
+	r = LoadTempDBWithPath(assert, td)
+	return r, td
+}
+
+func LoadTempDBWithPath(assert *assert.Assertions, td string) (r *DB) {
+	sp, err := spec.ForDatabase(td)
+	assert.NoError(err)
+	
+	noms := sp.GetDatabase()
+	r, err = NewDB(noms.GetDataset("tempaccount"))
+	assert.NoError(err)
+
+	return r
+}

--- a/serve/service.go
+++ b/serve/service.go
@@ -28,7 +28,7 @@ var (
 	pathRegex = regexp.MustCompile(`^\/([\w-]+)\/([\w-]+)\/([\w-]+)\/?$`)
 )
 
-// Service is a running instance of the Replicant service.
+// Service is an instance of the Replicache Diffserver services.
 type Service struct {
 	storageRoot          string
 	urlPrefix            string
@@ -47,8 +47,8 @@ type clientViewGetter interface {
 	Get(url string, req servetypes.ClientViewRequest, authToken string, syncID string) (servetypes.ClientViewResponse, int, error)
 }
 
-// Account is information about a customer of Replicant. This is a stand-in for what will eventually be
-// an accounts database.
+// Account represents a regular customer account (as opposed to an auto-signup account). 
+// This is a temporary stand-in that will be replaced by the account service.
 type Account struct {
 	ID            string
 	Name          string

--- a/serve/signup/get.html
+++ b/serve/signup/get.html
@@ -1,0 +1,27 @@
+<html>
+
+<head>
+    <title>Replicache Account Signup</title>
+</head>
+
+<body>
+    <h2>Replicache Account Signup</h2>
+
+    <p>Please fill out the form below to generate an Account ID for Replicache.<br>
+        You need to include your Account ID in the <i>diffServerAuth</i> field when<br>
+        you <a href="https://github.com/rocicorp/replicache-sdk-js#%EF%B8%8F-instantiate">instantiate Replicache</a>
+        in your JavaScript application.
+
+    <p>Note that while your Account ID will be useful for <strong>evaluating</strong> Replicache,<br>
+        it maybe subject to certain limits that make it unsuitable for large-scale production use. <br>
+        Please contact us by TODO in order to have your account upgraded for produdction use.<br><br>
+
+    <form method="POST" action="/signup">
+        <label>Name:</label> <input type="text" name="{{.Name}}"><br>
+        <label>Email:</label> <input type="text" name="{{.Email}}"><br>
+        <input type="submit">
+    </form>
+
+</body>
+
+</html>

--- a/serve/signup/post.html
+++ b/serve/signup/post.html
@@ -1,0 +1,14 @@
+<html>
+
+<head>
+    <title>Replicache Account Signup: Success!</title>
+</head>
+
+<body>
+    <h2>Success!</h2>
+
+    <h2>Your Account ID is {{ .ID }}</h2>
+    <!-- TODO add some more text here: pass it Replicache constructor, etc. -->
+</body>
+
+</html>

--- a/serve/signup/service.go
+++ b/serve/signup/service.go
@@ -1,0 +1,149 @@
+package signup
+
+import (
+	"fmt"
+	"html/template"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/attic-labs/noms/go/spec"
+	"github.com/gorilla/mux"
+	zl "github.com/rs/zerolog"
+	"roci.dev/diff-server/account"
+)
+
+// Add new templates to the list in TemplateFiles below.
+const getTemplate = "get.html"
+const postTemplate = "post.html"
+
+// TemplateFiles returns the paths to the templates this service uses.
+func TemplateFiles(templatesDir string) []string {
+	templates := []string{getTemplate, postTemplate}
+	files := []string{}
+
+	for _, t := range templates {
+		files = append(files, filepath.Join(templatesDir, t))
+	}
+	return files
+}
+
+// Service is an instance of the signup service. It returns a little form
+// to fill out with account information, accepts a POST from the form, and creates
+// the account in an account.DB.
+type Service struct {
+	logger      zl.Logger
+	tmpl        *template.Template
+	storageRoot string
+}
+
+// NewService instantiates the signup service. Handlers need to be registered with
+// RegisterHandlers.
+func NewService(logger zl.Logger, tmpl *template.Template, storageRoot string) *Service {
+	return &Service{logger, tmpl, storageRoot}
+}
+
+// Path is the URL path at which to serve.
+const Path = "/signup"
+
+// RegisterHandlers registers Service's handlers on the given router.
+func RegisterHandlers(s *Service, router *mux.Router) {
+	router.HandleFunc(Path, s.handle)
+}
+
+func (s *Service) handle(w http.ResponseWriter, r *http.Request) {
+	// TODO hook ASID check into Diffserver service
+	// TODO hook it up for vercel (serve/prod.go)
+	// TODO better error messages for errors in POST
+	// TODO light form validation eg missing email
+	// TODO retry if concurrent POSTs step on each other + test
+	// TODO logging
+	// TODO rate limiting
+	// TODO add more text/explanation to POST template (currently just has the ID)
+	// TODO figure out how to recommend they contact us and include in templates
+	// TODO purty
+	// TODO update setup instructions and docs to point to this service
+	// TODO update diffs instructions to include account-db and template-path
+	// TODO wipe prod account db to clean slate when we launch this feature
+	//      (ie, remove the noise from us tire-kicking)
+
+	if r.Method == "GET" {
+		if err := s.tmpl.ExecuteTemplate(w, getTemplate, getTemplateArgs{GetTemplateNameField, GetTemplateEmailField}); err != nil {
+			serverError(w, err, s.logger)
+		}
+		return
+
+	} else if r.Method == "POST" {
+		name := r.FormValue(GetTemplateNameField)
+		email := r.FormValue(GetTemplateEmailField)
+		// See TODOs above: we need light validation and better error messages
+		db, err := GetDB(s.storageRoot)
+		if err != nil {
+			serverError(w, err, s.logger)
+			return
+		}
+		accounts := db.HeadValue()
+		id := accounts.NextASID
+		accounts.AutoSignup[id] = account.ASAccount{
+			ASID:        id,
+			Name:        name,
+			Email:       email,
+			DateCreated: time.Now().String(),
+		}
+		accounts.NextASID++
+		if err := db.SetHeadWithValue(accounts); err != nil {
+			// See TODOs above: retry if head was changed from under us.
+			serverError(w, err, s.logger)
+			return
+		}
+		templateArgs := postTemplateArgs{ID: fmt.Sprintf("%d", id)}
+		if err := s.tmpl.ExecuteTemplate(w, postTemplate, templateArgs); err != nil {
+			serverError(w, err, s.logger)
+		}
+		return
+
+	} else {
+		unsupportedMethodError(w, r.Method, s.logger)
+	}
+}
+
+const GetTemplateNameField = "name"
+const GetTemplateEmailField = "email"
+
+// getTemplateArgs holds the names of the form fields to use in the form.
+// They're extracted into the constants above so they are easy to change if need be.
+type getTemplateArgs struct {
+	Name  string
+	Email string
+}
+
+type postTemplateArgs struct {
+	ID string // The newly created account id.
+}
+
+// GetDB returns the account DB.
+func GetDB(storageRoot string) (*account.DB, error) {
+	sp, err := spec.ForDatabase(fmt.Sprintf("%s/accounts", storageRoot))
+	if err != nil {
+		return nil, err
+	}
+	noms := sp.GetDatabase()
+	return account.NewDB(noms.GetDataset(fmt.Sprintf("websignup")))
+}
+
+func unsupportedMethodError(w http.ResponseWriter, m string, l zl.Logger) {
+	clientError(w, http.StatusMethodNotAllowed, fmt.Sprintf("Unsupported method: %s", m), l)
+}
+
+func clientError(w http.ResponseWriter, code int, body string, l zl.Logger) {
+	w.WriteHeader(code)
+	l.Info().Int("status", code).Msg(body)
+	io.Copy(w, strings.NewReader(body))
+}
+
+func serverError(w http.ResponseWriter, err error, l zl.Logger) {
+	w.WriteHeader(http.StatusInternalServerError)
+	l.Error().Int("status", http.StatusInternalServerError).Err(err).Send()
+}

--- a/serve/signup/service_test.go
+++ b/serve/signup/service_test.go
@@ -1,0 +1,81 @@
+package signup_test
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+	"io/ioutil"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"roci.dev/diff-server/serve/signup"
+	"roci.dev/diff-server/util/log"
+)
+
+func TestGET(t *testing.T) {
+	assert := assert.New(t)
+	dir, err := ioutil.TempDir("", "")
+	assert.NoError(err)
+	defer func() { assert.NoError(os.RemoveAll(dir)) }()
+
+	tmpl := template.Must(template.ParseFiles(signup.TemplateFiles(".")...))
+	service := signup.NewService(log.Default(), tmpl, dir)
+	m := mux.NewRouter()
+	signup.RegisterHandlers(service, m)
+
+	getForm := httptest.NewRequest("GET", signup.Path, nil)
+	getFormRecorder := httptest.NewRecorder()
+	m.ServeHTTP(getFormRecorder, getForm)
+	resp := getFormRecorder.Result()
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	assert.NoError(err)
+	assert.Equal(200, resp.StatusCode)
+	body := string(bodyBytes)
+	assert.True(strings.Contains(body, fmt.Sprintf(`name="%s"`, signup.GetTemplateNameField)))
+	assert.True(strings.Contains(body, fmt.Sprintf(`name="%s"`, signup.GetTemplateEmailField)))
+	assert.True(strings.Contains(body, `type="submit"`))
+}
+
+func TestPOST(t *testing.T) {
+	assert := assert.New(t)
+	dir, err := ioutil.TempDir("", "")
+	assert.NoError(err)
+	defer func() { assert.NoError(os.RemoveAll(dir)) }()
+
+	tmpl := template.Must(template.ParseFiles(signup.TemplateFiles(".")...))
+	service := signup.NewService(log.Default(), tmpl, dir)
+	m := mux.NewRouter()
+	signup.RegisterHandlers(service, m)
+	db, err := signup.GetDB(dir)
+	assert.NoError(err)
+	expectedASID := db.HeadValue().NextASID
+
+	postData := url.Values{}
+	postData.Set(signup.GetTemplateNameField, "Larry")
+	postData.Set(signup.GetTemplateEmailField, "larry@example.com")
+	postForm := httptest.NewRequest("POST", signup.Path, bytes.NewBufferString(postData.Encode()))
+	postForm.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	postFormRecorder := httptest.NewRecorder()
+	m.ServeHTTP(postFormRecorder, postForm)
+	resp := postFormRecorder.Result()
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	assert.NoError(err)
+
+	// Ensure repsonse is what we expect.
+	assert.Equal(200, resp.StatusCode)
+	body := string(bodyBytes)
+	assert.True(strings.Contains(body, fmt.Sprintf("ID is %d", expectedASID)))
+
+	// Ensure the account db was updated.
+	assert.NoError(db.Reload())
+	hv := db.HeadValue()
+	assert.Equal(expectedASID+1, hv.NextASID)
+	assert.Equal("Larry", hv.AutoSignup[expectedASID].Name)
+	assert.Equal("larry@example.com", hv.AutoSignup[expectedASID].Email)
+	assert.NotEqual("", hv.AutoSignup[expectedASID].DateCreated)
+}


### PR DESCRIPTION
still a number of TODOs (see signup.go)

not hooked up for vercel yet but can run locally with `./diffs --db=/tmp/foo --account-db=/tmp/bar serve --signup-template-dir=serve/signup`

@arv fyi

progress towards https://github.com/rocicorp/repc/issues/269