### PR TITLE
make signup work on vercel

### DIFF
--- a/api/diff-service.go
+++ b/api/diff-service.go
@@ -1,5 +1,4 @@
-// Package prod implements our top-level production server entrypoint for Zeit Now.
-package prod
+package api
 
 import (
 	"net/http"
@@ -22,10 +21,12 @@ const (
 	aws_access_key_id     = "REPLICANT_AWS_ACCESS_KEY_ID"
 	aws_secret_access_key = "REPLICANT_AWS_SECRET_ACCESS_KEY"
 	aws_region            = "us-west-2"
+
+	storageRoot = "aws:replicant/aa-replicant2"
 )
 
 var (
-	handler            http.Handler
+	diffServiceHandler http.Handler
 	headerLogWhitelist = []string{"Authorization", "Content-Type", "Host", "X-Replicache-SyncID"}
 )
 
@@ -45,7 +46,6 @@ func init() {
 					os.Getenv(aws_secret_access_key), ""))))
 	}
 
-	storageRoot := "aws:replicant/aa-replicant2"
 	accountDB, err := account.NewDB(storageRoot)
 	if err != nil {
 		panic(err)
@@ -54,10 +54,10 @@ func init() {
 	svc := serve.NewService(storageRoot, accountDB, "", serve.ClientViewGetter{}, false)
 	mux := mux.NewRouter()
 	serve.RegisterHandlers(svc, mux)
-	handler = mux
+	diffServiceHandler = mux
 }
 
-// Handler implements the Zeit Now entrypoint for our server.
-func Handler(w http.ResponseWriter, r *http.Request) {
-	handler.ServeHTTP(w, r)
+// DiffServiceHandler implements the Vercel entrypoint for the DiffService.
+func DiffServiceHandler(w http.ResponseWriter, r *http.Request) {
+	diffServiceHandler.ServeHTTP(w, r)
 }

--- a/api/signup-service.go
+++ b/api/signup-service.go
@@ -1,0 +1,50 @@
+package api
+
+import (
+	"html/template"
+	"net/http"
+	"os"
+
+	"github.com/attic-labs/noms/go/spec"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gorilla/mux"
+	zl "github.com/rs/zerolog"
+	zlog "github.com/rs/zerolog/log"
+
+	"roci.dev/diff-server/serve/signup"
+	"roci.dev/diff-server/util/log"
+)
+
+var (
+	signupHandler http.Handler
+)
+
+func init() {
+	zl.SetGlobalLevel(zl.DebugLevel)
+	zlog.Logger = zlog.Output(zl.ConsoleWriter{Out: os.Stderr, TimeFormat: "02 Jan 06 15:04:05.000 -0700", NoColor: true})
+	spec.GetAWSSession = func() *session.Session {
+		return session.Must(session.NewSession(
+			aws.NewConfig().WithRegion(aws_region).WithCredentials(
+				// Have to do this wackiness because not allowed to set AWS env variables in Now for some reason.
+				credentials.NewStaticCredentials(
+					os.Getenv(aws_access_key_id),
+					os.Getenv(aws_secret_access_key), ""))))
+	}
+
+	// TODO should probably be sharing a mux with DiffService.
+	mux := mux.NewRouter()
+
+	// Set up signup service.
+	tmpl := template.Must(signup.ParseTemplates(signup.Templates()))
+	service := signup.NewService(log.Default(), tmpl, storageRoot)
+	signup.RegisterHandlers(service, mux)
+
+	signupHandler = mux
+}
+
+// SignupHandler implements the Vercel entrypoint for the signup service.
+func SignupHandler(w http.ResponseWriter, r *http.Request) {
+	signupHandler.ServeHTTP(w, r)
+}

--- a/cmd/diffs/main.go
+++ b/cmd/diffs/main.go
@@ -125,7 +125,6 @@ func serve(parent *kingpin.Application, sps *string, ads *string, errs io.Writer
 	port := kc.Flag("port", "The port to run on").Default("7001").Int()
 	enableInject := kc.Flag("enable-inject", "Enable /inject endpoint which writes directly to the database for testing").Default("false").Bool()
 	overrideClientViewURL := parent.Flag("client-view", "URL to use for all accounts' Client View").PlaceHolder("http://localhost:8000/replicache-client-view").Default("").String()
-	signupTemplateDir := kc.Flag("signup-template-dir", "Directory containing signup templates (eg diff-server/serve/signup)").Default("").String()
 	kc.Action(func(_ *kingpin.ParseContext) error {
 		l.Info().Msgf("Listening on %d...", *port)
 
@@ -144,7 +143,7 @@ func serve(parent *kingpin.Application, sps *string, ads *string, errs io.Writer
 		servepkg.RegisterHandlers(svc, mux)
 
 		// Set up signup service.
-		tmpl := template.Must(template.ParseFiles(signup.TemplateFiles(*signupTemplateDir)...))
+		tmpl := template.Must(signup.ParseTemplates(signup.Templates()))
 		service := signup.NewService(l, tmpl, *ads)
 		signup.RegisterHandlers(service, mux)
 

--- a/cmd/diffs/main_test.go
+++ b/cmd/diffs/main_test.go
@@ -33,7 +33,7 @@ func TestServe(t *testing.T) {
 
 	defer time.SetFake()()
 
-	args := append([]string{"--db=" + dir, "--account-db=" + accountDBDir, "serve", "--signup-template-dir=../../serve/signup", "--port=8674"})
+	args := append([]string{"--db=" + dir, "--account-db=" + accountDBDir, "serve", "--port=8674"})
 	go impl(args, strings.NewReader(""), os.Stdout, os.Stderr, func(_ int) {})
 
 	// Wait for server to start...

--- a/now.json
+++ b/now.json
@@ -1,10 +1,18 @@
 {
     "version": 2,
-    "builds": [
-        { "src": "serve/prod/prod.go", "use": "@now/go" }
-    ],
-    "routes": [
-        { "src": "/.*", "dest": "/serve/prod/prod.go" }
+    "rewrites": [
+        {
+            "source": "/inject",
+            "destination": "/api/diff-service"
+        },
+        {
+            "source": "/pull",
+            "destination": "/api/diff-service"
+        },
+        {
+            "source": "/signup",
+            "destination": "/api/signup-service"
+        }
     ],
     "env": {
         "REPLICANT_AWS_ACCESS_KEY_ID": "@aws_access_key_id",

--- a/serve/signup/get.go
+++ b/serve/signup/get.go
@@ -1,3 +1,13 @@
+package signup
+
+const GetTemplateName = "get"
+
+// GetTemplate is the HTML template for the page a customer uses to sign up.
+// The template is included statically because I cannot figure out how
+// to get Vercel to include template files so they are accessible at function
+// startup time. (I tried both "functions" with includeFiles and static
+// build rules.)
+const GetTemplate = `
 <!doctype html>
 <html>
 
@@ -26,3 +36,4 @@
 </body>
 
 </html>
+`

--- a/serve/signup/post.go
+++ b/serve/signup/post.go
@@ -1,3 +1,10 @@
+package signup
+
+const PostTemplateName = "post"
+
+// PostTemplate is the HTML template rendered in response to a
+// customer signup.
+const PostTemplate = `
 <html>
 
 <head>
@@ -12,3 +19,4 @@
 </body>
 
 </html>
+`

--- a/serve/signup/service_test.go
+++ b/serve/signup/service_test.go
@@ -24,7 +24,7 @@ func TestGET(t *testing.T) {
 	assert.NoError(err)
 	defer func() { assert.NoError(os.RemoveAll(dir)) }()
 
-	tmpl := template.Must(template.ParseFiles(signup.TemplateFiles(".")...))
+	tmpl := template.Must(signup.ParseTemplates(signup.Templates()))
 	service := signup.NewService(log.Default(), tmpl, dir)
 	m := mux.NewRouter()
 	signup.RegisterHandlers(service, m)
@@ -48,7 +48,7 @@ func TestPOST(t *testing.T) {
 	assert.NoError(err)
 	defer func() { assert.NoError(os.RemoveAll(dir)) }()
 
-	tmpl := template.Must(template.ParseFiles(signup.TemplateFiles(".")...))
+	tmpl := template.Must(signup.ParseTemplates(signup.Templates()))
 	service := signup.NewService(log.Default(), tmpl, dir)
 	m := mux.NewRouter()
 	signup.RegisterHandlers(service, m)


### PR DESCRIPTION
i tried and tried to get template files to be accessible in vercel but couldn't get it to work. so instead include the templates as static strings in the binary. also move to a more idiomatic way of mounting the api, using the /api directory. this will make using vercel features easier.

progress towards https://github.com/rocicorp/repc/issues/269