### PR TITLE
enable auto-add of auto-signup clientview urls 

### DIFF
--- a/account/db.go
+++ b/account/db.go
@@ -86,8 +86,12 @@ func (db *DB) Noms() datas.Database {
 	return db.ds.Database()
 }
 
-// Callers don't care about the underlying Commit structure, so we have
-// HeadValue and SetHeadWithValue, unlike db/db.go, which has Head and SetHead.
+// HeadValue returns the value at head. Note that the Records returned contains
+// pointer types (eg, a map) so any changes to the pointer members of the Records
+// returned will be visible to any other caller to whom this Records has been
+// returned. Use CopyRecords to get a value that is safe to change. This is
+// not a good pattern, especially because Noms might require retry on write,
+// but luckily this is a temporary thing. (Reader two years in the future: <smirks>.)
 func (db *DB) HeadValue() Records {
 	defer db.lock()()
 	return db.head.Value

--- a/account/list.go
+++ b/account/list.go
@@ -1,10 +1,11 @@
 package account
 
 var (
-	regularAccounts = []Record{
+	RegularAccounts = []Record{
 		{
-			ID:   0,
-			Name: "Sandbox",
+			ID:             0,
+			Name:           "Sandbox",
+			ClientViewURLs: []string{"http://replicache.dev"},
 		},
 		{
 			ID:             1,

--- a/account/records.go
+++ b/account/records.go
@@ -4,13 +4,24 @@ import (
 	"strconv"
 )
 
-// Records is the full set of Replicache account records. These
-// records come from two places for now (auto-signup accounts from
-// noms and regular accounts from our hard-coded list), so it is
-// important to use ReadRecords() to be sure you get them all.
+// Records contains the set of Replicache account records (all of them
+// if read with ReadAllRecords, just those from the DB if read with
+// ReadRecords).
 type Records struct {
 	NextASID uint32
 	Record   map[uint32]Record // Map key is the ID.
+}
+
+// CopyRecords deep copies Records (it contains a pointer type).
+func CopyRecords(records Records) Records {
+	copy := Records{
+		NextASID: records.NextASID,
+		Record:   make(map[uint32]Record, len(records.Record)),
+	}
+	for _, record := range records.Record {
+		copy.Record[record.ID] = CopyRecord(record)
+	}
+	return copy
 }
 
 // Record represents a single account record.
@@ -22,39 +33,64 @@ type Record struct {
 	DateCreated    string
 }
 
+// CopyRecord deep copies a Record (it contains a pointer type).
+func CopyRecord(record Record) Record {
+	copy := Record{
+		ID:             record.ID,
+		Name:           record.Name,
+		Email:          record.Email,
+		ClientViewURLs: make([]string, 0, len(record.ClientViewURLs)),
+		DateCreated:    record.DateCreated,
+	}
+	for _, url := range record.ClientViewURLs {
+		copy.ClientViewURLs = append(copy.ClientViewURLs, url)
+	}
+	return copy
+}
+
 // ASIDs are issued in a separate range from regular accounts.
 // See RFC: https://github.com/rocicorp/repc/issues/269
 const LowestASID uint32 = 1000000
 
-// ReadRecords returns the full set of Replicache account records. Reading
+// We limit the number of auto-added client view URLs for auto-signup accounts.
+const MaxASClientViewURLs int = 10
+
+// ReadAllRecords returns the full set of Replicache account records. Reading
 // of Records is separate from Lookup so the caller can cache Records if they
 // so desire (it doesn't change very often).
-func ReadRecords(db *DB) (Records, error) {
-	if err := db.Reload(); err != nil {
+func ReadAllRecords(db *DB) (Records, error) {
+	dbRecords, err := ReadRecords(db)
+	if err != nil {
 		return Records{}, err
 	}
-	records := db.HeadValue()
 
-	// records.Record is a map, which is a reference type, so we make
-	// a copy of it to prevent aliasing bugs. A different API could
-	// eliminate this copy, but this is an easy starting point.
-	recordMap := records.Record
-	records.Record = map[uint32]Record{}
-	for k, v := range recordMap {
-		// We'll add the regular accounts in a following step.
-		if k >= LowestASID {
-			records.Record[k] = v
+	// Now overlay the hard-coded regular accounts, removing any stale regular
+	// account records that might have been saved. Since we are mutating records
+	// we make a copy of it first :( Otherwise others who have a handle on it
+	// will see our changes.
+	//
+	// And yes ugh: records are iterated in random order so this iterates
+	// ALL our account records.
+	records := CopyRecords(dbRecords)
+	for _, record := range records.Record {
+		if record.ID < LowestASID {
+			delete(records.Record, record.ID)
 		}
 	}
-
-	// Now overlay the hard-coded regular accounts. Yes a copy of these
-	// records will have been saved to noms, but we want to use the hardcoded
-	// version.
-	for _, record := range regularAccounts {
+	for _, record := range RegularAccounts {
 		records.Record[record.ID] = record
 	}
 
 	return records, nil
+}
+
+// ReadRecords reads records from the db WITHOUT overlaying the production
+// account records.
+func ReadRecords(db *DB) (Records, error) {
+	if err := db.Reload(); err != nil {
+		return Records{}, err
+	}
+	return db.HeadValue(), nil
 }
 
 // Lookup returns the account record for the given authorization string
@@ -79,9 +115,52 @@ func Lookup(records Records, authorization string) (Record, bool) {
 
 // WriteRecords writes the given records to the underlying db. It might
 // return an RetryError in which case the caller should retry the entire
-// operation: re-read Records with ReadRecords, apply changes, and call
-// WriteRecords again. Do not retry if the returned error cannot be
+// operation: re-read Records with ReadRecords, copy it, apply changes,
+// and call WriteRecords again. Do not retry if the returned error cannot be
 // converted to a RetryError (via errors.As).
 func WriteRecords(db *DB, records Records) error {
 	return db.SetHeadWithValue(records)
+}
+
+// ClientViewURLAuthorized returns a bool indicating whether the URL the client
+// is attempting to fetch from is authorized. We allow auto-signup accounts to
+// fetch their client view from any URL up to some number of unique URLs. We
+// limit this number to prevent spamming and require fixed, explicitly configured
+// URLs for the non-ASID case for security.
+//
+// ClientViewURLAuthorized assumes that records is mutable. If the caller doesn't
+// want to see changes from ClientViewURLAuthorized it should pass in a copy from
+// CopyRecords().
+func ClientViewURLAuthorized(maxASClientViewURLs int, db *DB, records Records, ID uint32, url string) (bool, error) {
+	record, exists := records.Record[ID]
+	if !exists {
+		return false, nil
+	}
+
+	for _, authorizedURL := range record.ClientViewURLs {
+		if url == authorizedURL {
+			return true, nil
+		}
+	}
+	// Regular accounts have a fixed list of authorized URLs.
+	if !isASID(record.ID) {
+		return false, nil
+	}
+
+	// Here we know this is an auto-signup account and the url is not in the list.
+	if len(record.ClientViewURLs) >= maxASClientViewURLs {
+		return false, nil
+	}
+
+	record.ClientViewURLs = append(record.ClientViewURLs, url)
+	records.Record[record.ID] = record
+	// TODO retry
+	if err := WriteRecords(db, records); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func isASID(id uint32) bool {
+	return id >= LowestASID
 }

--- a/account/tempdb.go
+++ b/account/tempdb.go
@@ -22,10 +22,19 @@ func LoadTempDBWithPath(assert *assert.Assertions, td string) (r *DB) {
 
 const UnittestID = 0xFFFFFFFF
 
-func AddUnittestAccountWithURL(assert *assert.Assertions, db *DB, clientViewURL string) {
-	accounts, err := ReadRecords(db)
+func AddUnittestAccount(assert *assert.Assertions, db *DB) {
+	accounts, err := ReadAllRecords(db)
 	assert.NoError(err)
-	record := Record{ID: UnittestID, Name: "Unittest", ClientViewURLs: []string{clientViewURL}}
+	record := Record{ID: UnittestID, Name: "Unittest", ClientViewURLs: []string{}}
 	accounts.Record[record.ID] = record
+	assert.NoError(WriteRecords(db, accounts))
+}
+
+func AddUnittestAccountURL(assert *assert.Assertions, db *DB, url string) {
+	accounts, err := ReadAllRecords(db)
+	assert.NoError(err)
+	record := accounts.Record[UnittestID]
+	record.ClientViewURLs = append(record.ClientViewURLs, url)
+	accounts.Record[UnittestID] = record
 	assert.NoError(WriteRecords(db, accounts))
 }

--- a/api/diff-service.go
+++ b/api/diff-service.go
@@ -51,7 +51,7 @@ func init() {
 		panic(err)
 	}
 
-	svc := serve.NewService(storageRoot, accountDB, "", serve.ClientViewGetter{}, false)
+	svc := serve.NewService(storageRoot, account.MaxASClientViewURLs, accountDB, "", serve.ClientViewGetter{}, false)
 	mux := mux.NewRouter()
 	serve.RegisterHandlers(svc, mux)
 	diffServiceHandler = mux

--- a/cmd/diffs/main.go
+++ b/cmd/diffs/main.go
@@ -138,7 +138,7 @@ func serve(parent *kingpin.Application, sps *string, ads *string, errs io.Writer
 			panic(err)
 		}
 
-		svc := servepkg.NewService(*sps, accountDB, *overrideClientViewURL, servepkg.ClientViewGetter{}, *enableInject)
+		svc := servepkg.NewService(*sps, account.MaxASClientViewURLs, accountDB, *overrideClientViewURL, servepkg.ClientViewGetter{}, *enableInject)
 		mux := mux.NewRouter()
 		servepkg.RegisterHandlers(svc, mux)
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/rs/zerolog v1.18.0
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b // indirect
-	golang.org/x/sys v0.0.0-20190509141414-a5b02f93d862 // indirect
+	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb // indirect
 	golang.org/x/text v0.3.2 // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190509141414-a5b02f93d862 h1:rM0ROo5vb9AdYJi1110yjWGMej9ITfKddS89P3Fkhug=
-golang.org/x/sys v0.0.0-20190509141414-a5b02f93d862/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb h1:fgwFCsaw9buMuxNd6+DQfAuSFqbNiQZpcgJQAgJsK6k=
+golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=

--- a/serve/hello_test.go
+++ b/serve/hello_test.go
@@ -39,7 +39,7 @@ func TestHello(t *testing.T) {
 		adb, adir := account.LoadTempDB(assert)
 		defer func() { assert.NoError(os.RemoveAll(adir)) }()
 
-		s := NewService(td, adb, "", nil, true)
+		s := NewService(td, account.MaxASClientViewURLs, adb, "", nil, true)
 
 		msg := fmt.Sprintf("test case %d", i)
 		req := httptest.NewRequest(t.method, "/hello", nil)

--- a/serve/inject.go
+++ b/serve/inject.go
@@ -39,7 +39,7 @@ func (s *Service) inject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// This check seems kind of useless given that much account info is public.
-	records, err := account.ReadRecords(s.accountDB)
+	records, err := account.ReadAllRecords(s.accountDB)
 	if err != nil {
 		serverError(w, err, l)
 	}

--- a/serve/inject_test.go
+++ b/serve/inject_test.go
@@ -58,9 +58,9 @@ func TestInject(t *testing.T) {
 
 		adb, adir := account.LoadTempDB(assert)
 		defer func() { assert.NoError(os.RemoveAll(adir)) }()
-		account.AddUnittestAccountWithURL(assert, adb, "")
+		account.AddUnittestAccount(assert, adb)
 
-		s := NewService(td, adb, "", nil, t.injectEnabled)
+		s := NewService(td, account.MaxASClientViewURLs, adb, "", nil, t.injectEnabled)
 
 		msg := fmt.Sprintf("test case %d", i)
 		req := httptest.NewRequest(t.method, "/inject", strings.NewReader(t.req))

--- a/serve/pull_test.go
+++ b/serve/pull_test.go
@@ -31,6 +31,297 @@ func TestAPI(t *testing.T) {
 		pullMethod  string
 		pullReq     string
 		authHeader  string
+		expCVURL    string
+		expCVAuth   string
+		CVResponse  servetypes.ClientViewResponse
+		CVCode      int
+		CVErr       error
+		expPullResp string
+		expPullErr  string
+	}{
+		// Unsupported method
+		{"GET",
+			`{"baseStateID": "00000000000000000000000000000000", "checksum": "00000000", "lastMutationID": 0, "clientID": "clientid", "clientViewURL": "http://cv", "version": 3}`,
+			unittestID,
+			"",
+			"",
+			servetypes.ClientViewResponse{},
+			0,
+			nil,
+			``,
+			"Unsupported method: GET"},
+
+		// Supports OPTIONS for cors headers
+		{"OPTIONS",
+			``,
+			unittestID,
+			"",
+			"",
+			servetypes.ClientViewResponse{},
+			0,
+			nil,
+			``,
+			""},
+
+		// Missing clientViewURL
+		{"POST",
+			`{"baseStateID": "00000000000000000000000000000000", "checksum": "00000000", "lastMutationID": 0, "clientID": "clientid", "version": 3}`,
+			unittestID,
+			"",
+			"",
+			servetypes.ClientViewResponse{},
+			0,
+			nil,
+			"",
+			"clientViewURL not provided in request"},
+
+		// Client view URL not authorized (service is configured with 1 max, already has 1.)
+		{"POST",
+			`{"baseStateID": "00000000000000000000000000000000", "checksum": "00000000", "lastMutationID": 0, "clientID": "clientid", "clientViewAuth": "clientauth", "clientViewURL": "http://cv2.com", "version": 3}`,
+			unittestID,
+			"",
+			"",
+			servetypes.ClientViewResponse{},
+			0,
+			nil,
+			"",
+			"clientViewURL is not authorized"},
+
+		// Successful client view fetch.
+		{"POST",
+			`{"baseStateID": "00000000000000000000000000000000", "checksum": "00000000", "lastMutationID": 0, "clientID": "clientid", "clientViewAuth": "clientauth", "clientViewURL": "http://cv", "version": 3}`,
+			unittestID,
+			"http://cv",
+			"clientauth",
+			servetypes.ClientViewResponse{ClientView: map[string]json.RawMessage{"new": b(`"value"`)}, LastMutationID: 2},
+			200,
+			nil,
+			`{"stateID":"hoc705ifecv1c858qgbqr9jghh4d9l96","lastMutationID":2,"patch":[{"op":"replace","path":"","valueString":"{}"},{"op":"add","path":"/new","valueString":"\"value\""}],"checksum":"f9ef007b","clientViewInfo":{"httpStatusCode":200,"errorMessage":""}}`,
+			""},
+
+		// Successful nop client view fetch where lastMutationID does not change.
+		{"POST",
+			`{"baseStateID": "s3n5j759kirvvs3fqeott07a43lk41ud", "checksum": "c4e7090d", "lastMutationID": 1, "clientID": "clientid", "clientViewAuth": "clientauth", "clientViewURL": "http://cv", "version": 3}`,
+			unittestID,
+			"http://cv",
+			"clientauth",
+			servetypes.ClientViewResponse{ClientView: map[string]json.RawMessage{"foo": b(`"bar"`)}, LastMutationID: 1},
+			200,
+			nil,
+			`{"stateID":"s3n5j759kirvvs3fqeott07a43lk41ud","lastMutationID":1,"patch":[],"checksum":"c4e7090d","clientViewInfo":{"httpStatusCode":200,"errorMessage":""}}`,
+			""},
+
+		// Successful nop client view fetch where lastMutationID does change.
+		{"POST",
+			`{"baseStateID": "s3n5j759kirvvs3fqeott07a43lk41ud", "checksum": "c4e7090d", "lastMutationID": 1, "clientID": "clientid", "clientViewAuth": "clientauth", "clientViewURL": "http://cv", "version": 3}`,
+			unittestID,
+			"http://cv",
+			"clientauth",
+			servetypes.ClientViewResponse{ClientView: map[string]json.RawMessage{"foo": b(`"bar"`)}, LastMutationID: 77},
+			200,
+			nil,
+			`{"stateID":"pi99ftvp6nchoej3i58flsqm8enqg4vd","lastMutationID":77,"patch":[],"checksum":"c4e7090d","clientViewInfo":{"httpStatusCode":200,"errorMessage":""}}`,
+			""},
+
+		// Client view returns LMID < diffserver's => nop
+		{"POST",
+			`{"baseStateID": "s3n5j759kirvvs3fqeott07a43lk41ud", "checksum": "c4e7090d", "lastMutationID": 1, "clientID": "clientid", "clientViewAuth": "clientauth", "clientViewURL": "http://cv", "version": 3}`,
+			unittestID,
+			"http://cv",
+			"clientauth",
+			servetypes.ClientViewResponse{ClientView: map[string]json.RawMessage{"foo": b(`"bar"`)}, LastMutationID: 0},
+			200,
+			nil,
+			`{"stateID":"s3n5j759kirvvs3fqeott07a43lk41ud","lastMutationID":1,"patch":[],"checksum":"c4e7090d","clientViewInfo":{"httpStatusCode":200,"errorMessage":""}}`,
+			""},
+
+		// Fetch errors out.
+		{"POST",
+			`{"baseStateID": "00000000000000000000000000000000", "checksum": "00000000", "lastMutationID": 0, "clientID": "clientid", "clientViewAuth": "clientauth", "clientViewURL": "http://cv", "version": 3}`,
+			unittestID,
+			"http://cv",
+			"clientauth",
+			servetypes.ClientViewResponse{ClientView: map[string]json.RawMessage{"new": b(`"value"`)}, LastMutationID: 2},
+			200,
+			errors.New("boom"),
+			`{"stateID":"s3n5j759kirvvs3fqeott07a43lk41ud","lastMutationID":1,"patch":[{"op":"replace","path":"","valueString":"{}"},{"op":"add","path":"/foo","valueString":"\"bar\""}],"checksum":"c4e7090d","clientViewInfo":{"httpStatusCode":200,"errorMessage":""}}`,
+			""},
+
+		// Diffserver has LMID < client's => nop (fetch is also erroring in this one, but that's incidental)
+		{"POST",
+			`{"baseStateID": "12345000000000000000000000000000", "checksum": "12345678", "lastMutationID": 22, "clientID": "clientid", "clientViewAuth": "clientauth", "clientViewURL": "http://cv", "version": 3}`,
+			unittestID,
+			"http://cv",
+			"clientauth",
+			servetypes.ClientViewResponse{},
+			0,
+			errors.New("boom"),
+			`{"stateID":"12345000000000000000000000000000","lastMutationID":22,"patch":[],"checksum":"12345678","clientViewInfo":{"httpStatusCode":0,"errorMessage":""}}`,
+			""},
+
+		// No Authorization header.
+		{"POST",
+			`{"baseStateID": "00000000000000000000000000000000", "checksum": "00000000", "lastMutationID": 0, "clientID": "clientid", "clientViewAuth": "clientauth", "clientViewURL": "http://cv", "version": 3}`,
+			"",
+			"",
+			"",
+			servetypes.ClientViewResponse{},
+			0,
+			nil,
+			``,
+			"Missing Authorization"},
+
+		// Unsupported version
+		{"POST",
+			`{"baseStateID": "00000000000000000000000000000000", "checksum": "00000000", "lastMutationID": 0, "clientID": "clientid", "clientViewAuth": "clientauth", "version": 1}`,
+			unittestID,
+			"",
+			"",
+			servetypes.ClientViewResponse{},
+			0,
+			nil,
+			``,
+			"Unsupported PullRequest version"},
+
+		// Unknown account passed in Authorization header.
+		{"POST",
+			`{"baseStateID": "00000000000000000000000000000000", "checksum": "00000000", "lastMutationID": 0, "clientID": "clientid", "clientViewAuth": "clientauth", "clientViewURL": "http://cv", "version": 3}`,
+			"BONK",
+			"",
+			"",
+			servetypes.ClientViewResponse{},
+			0,
+			nil,
+			``,
+			"Unknown account"},
+
+		// No clientID passed in.
+		{"POST",
+			`{"baseStateID": "00000000000000000000000000000000", "checksum": "00000000", "lastMutationID": 0, "clientViewAuth": "clientauth", "clientViewURL": "http://cv", "version": 3}`,
+			unittestID,
+			"",
+			"",
+			servetypes.ClientViewResponse{},
+			0,
+			nil,
+			``,
+			"Missing clientID"},
+
+		// Invalid baseStateID.
+		{"POST",
+			`{"baseStateID": "beep", "checksum": "00000000", "clientID": "clientid", "lastMutationID": 0, "clientViewAuth": "clientauth", "clientViewURL": "http://cv", "version": 3}`,
+			unittestID,
+			"",
+			"",
+			servetypes.ClientViewResponse{},
+			0,
+			nil,
+			``,
+			"Invalid baseStateID"},
+
+		// No baseStateID is fine (first pull).
+		{"POST",
+			`{"baseStateID": "", "checksum": "00000000", "lastMutationID": 0, "clientID": "clientid", "clientViewAuth": "clientauth", "clientViewURL": "http://cv", "version": 3}`,
+			unittestID,
+			"http://cv",
+			"clientauth",
+			servetypes.ClientViewResponse{ClientView: map[string]json.RawMessage{"new": b(`"value"`)}, LastMutationID: 2},
+			200,
+			nil,
+			`{"stateID":"hoc705ifecv1c858qgbqr9jghh4d9l96","lastMutationID":2,"patch":[{"op":"replace","path":"","valueString":"{}"},{"op":"add","path":"/new","valueString":"\"value\""}],"checksum":"f9ef007b","clientViewInfo":{"httpStatusCode":200,"errorMessage":""}}`,
+			""},
+
+		// Invalid checksum.
+		{"POST",
+			`{"baseStateID": "00000000000000000000000000000000", "checksum": "not", "lastMutationID": 0, "clientID": "clientid", "clientViewAuth": "clientauth", "clientViewURL": "http://cv", "version": 3}`,
+			unittestID,
+			"",
+			"",
+			servetypes.ClientViewResponse{},
+			0,
+			nil,
+			``,
+			"Invalid checksum"},
+
+		// Ensure it canonicalizes the client view JSON.
+		{"POST",
+			`{"baseStateID": "00000000000000000000000000000000", "checksum": "00000000", "lastMutationID": 0, "clientID": "clientid", "clientViewAuth": "clientauth", "clientViewURL": "http://cv", "version": 3}`,
+			unittestID,
+			"http://cv",
+			"clientauth",
+			servetypes.ClientViewResponse{ClientView: map[string]json.RawMessage{"new": b(`"\u000b"`)}, LastMutationID: 2}, // "\u000B" is canonical
+			200,
+			nil,
+			`{"stateID":"qv7hd0v4i49utb1gjs2hiefh1vfhjegk","lastMutationID":2,"patch":[{"op":"replace","path":"","valueString":"{}"},{"op":"add","path":"/new","valueString":"\"\\u000B\""}],"checksum":"b2dc0d6a","clientViewInfo":{"httpStatusCode":200,"errorMessage":""}}`,
+			""},
+	}
+
+	for i, t := range tc {
+		fcvg := &fakeClientViewGet{resp: t.CVResponse, code: t.CVCode, err: t.CVErr}
+		td, _ := ioutil.TempDir("", "")
+		defer func() { assert.NoError(os.RemoveAll(td)) }()
+
+		adb, adir := account.LoadTempDB(assert)
+		defer func() { assert.NoError(os.RemoveAll(adir)) }()
+		account.AddUnittestAccount(assert, adb)
+		account.AddUnittestAccountURL(assert, adb, "http://cv")
+
+		s := NewService(td, 1 /* max auto-signup account view URLs */, adb, "", fcvg, true)
+		noms, err := s.getNoms(unittestID)
+		assert.NoError(err)
+		db, err := db.New(noms.GetDataset("client/clientid"))
+		assert.NoError(err)
+		m := kv.NewMapForTest(noms, "foo", `"bar"`)
+		c, err := db.MaybePutData(m, 1 /*lastMutationID*/)
+		assert.NoError(err)
+		assert.False(c.NomsStruct.IsZeroValue())
+
+		msg := fmt.Sprintf("test case %d: %s", i, t.pullReq)
+		req := httptest.NewRequest(t.pullMethod, "/sync", strings.NewReader(t.pullReq))
+		req.Header.Set("Content-type", "application/json")
+		if t.authHeader != "" {
+			req.Header.Set("Authorization", t.authHeader)
+		}
+		req.Header.Set("X-Replicache-SyncID", "syncID")
+		resp := httptest.NewRecorder()
+		s.pull(resp, req)
+
+		body := bytes.Buffer{}
+		_, err = io.Copy(&body, resp.Result().Body)
+		assert.NoError(err, msg)
+		if t.expPullErr == "" {
+			assert.True(len(resp.Result().Header.Get("Access-Control-Allow-Origin")) > 0)
+			assert.True(len(resp.Result().Header.Get("Access-Control-Allow-Methods")) > 0)
+			assert.True(len(resp.Result().Header.Get("Access-Control-Allow-Headers")) > 0)
+			if t.pullMethod == "OPTIONS" {
+				assert.Equal(200, resp.Result().StatusCode)
+				continue
+			}
+			assert.Equal("application/json", resp.Result().Header.Get("Content-type"))
+			assert.Equal(t.expPullResp+"\n", string(body.Bytes()), msg)
+		} else {
+			assert.Regexp(t.expPullErr, string(body.Bytes()), msg)
+		}
+		if t.expCVURL != "" {
+			assert.True(fcvg.called, msg)
+			assert.Equal(t.expCVURL, fcvg.gotURL, msg)
+			assert.Equal(t.expCVAuth, fcvg.gotAuth, msg)
+			assert.Equal("clientid", fcvg.gotClientID)
+			assert.Equal("syncID", fcvg.gotSyncID)
+		}
+	}
+}
+
+func TestAPIV2(t *testing.T) {
+	assert := assert.New(t)
+	defer time.SetFake()()
+
+	unittestID := fmt.Sprintf("%d", account.UnittestID)
+
+	tc := []struct {
+		pullMethod  string
+		pullReq     string
+		authHeader  string
 		accountCV   string
 		overrideCV  string
 		expCVAuth   string
@@ -292,9 +583,10 @@ func TestAPI(t *testing.T) {
 
 		adb, adir := account.LoadTempDB(assert)
 		defer func() { assert.NoError(os.RemoveAll(adir)) }()
-		account.AddUnittestAccountWithURL(assert, adb, t.accountCV)
+		account.AddUnittestAccount(assert, adb)
+		account.AddUnittestAccountURL(assert, adb, t.accountCV)
 
-		s := NewService(td, adb, t.overrideCV, fcvg, true)
+		s := NewService(td, account.MaxASClientViewURLs, adb, t.overrideCV, fcvg, true)
 		noms, err := s.getNoms(unittestID)
 		assert.NoError(err)
 		db, err := db.New(noms.GetDataset("client/clientid"))

--- a/serve/service.go
+++ b/serve/service.go
@@ -33,6 +33,7 @@ var (
 type Service struct {
 	storageRoot          string
 	urlPrefix            string
+	maxASClientViewURLs  int
 	accountDB            *account.DB
 	nomsen               map[string]datas.Database
 	overridClientViewURL string // Overrides account client view URL, eg for testing.
@@ -49,9 +50,10 @@ type clientViewGetter interface {
 }
 
 // NewService creates a new instances of the Replicant web service.
-func NewService(storageRoot string, accountDB *account.DB, overrideClientViewURL string, cvg clientViewGetter, enableInject bool) *Service {
+func NewService(storageRoot string, maxASClientViewURLs int, accountDB *account.DB, overrideClientViewURL string, cvg clientViewGetter, enableInject bool) *Service {
 	return &Service{
 		storageRoot:          storageRoot,
+		maxASClientViewURLs:  maxASClientViewURLs,
 		accountDB:            accountDB,
 		nomsen:               map[string]datas.Database{},
 		overridClientViewURL: overrideClientViewURL,

--- a/serve/service_test.go
+++ b/serve/service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"roci.dev/diff-server/account"
+	"roci.dev/diff-server/serve/types"
 )
 
 func TestConcurrentAccessUsingMultipleServices(t *testing.T) {
@@ -22,8 +23,9 @@ func TestConcurrentAccessUsingMultipleServices(t *testing.T) {
 	adb, adir := account.LoadTempDB(assert)
 	defer func() { assert.NoError(os.RemoveAll(adir)) }()
 
-	svc1 := NewService(td, adb, "", nil, true)
-	svc2 := NewService(td, adb, "", nil, true)
+	fcvg := &fakeClientViewGet{resp: types.ClientViewResponse{}, code: 200, err: nil}
+	svc1 := NewService(td, account.MaxASClientViewURLs, adb, "", fcvg, true)
+	svc2 := NewService(td, account.MaxASClientViewURLs, adb, "", fcvg, true)
 
 	res := []*httptest.ResponseRecorder{
 		httptest.NewRecorder(),
@@ -31,11 +33,13 @@ func TestConcurrentAccessUsingMultipleServices(t *testing.T) {
 		httptest.NewRecorder(),
 	}
 
-	req1 := httptest.NewRequest("POST", "/pull", strings.NewReader(`{"baseStateID": "00000000000000000000000000000000", "checksum": "00000000", "clientID": "clientid", "version": 2}`))
+	reqBody := `{"baseStateID": "00000000000000000000000000000000", "checksum": "00000000", "clientID": "clientid", "clientViewURL": "http://replicache.dev", "version": 3}`
+
+	req1 := httptest.NewRequest("POST", "/pull", strings.NewReader(reqBody))
 	req1.Header.Add("Authorization", "sandbox")
-	req2 := httptest.NewRequest("POST", "/pull", strings.NewReader(`{"baseStateID": "00000000000000000000000000000000", "checksum": "00000000", "clientID": "clientid", "version": 2}`))
+	req2 := httptest.NewRequest("POST", "/pull", strings.NewReader(reqBody))
 	req2.Header.Add("Authorization", "sandbox")
-	req3 := httptest.NewRequest("POST", "/pull", strings.NewReader(`{"baseStateID": "00000000000000000000000000000000", "checksum": "00000000", "clientID": "clientid", "version": 2}`))
+	req3 := httptest.NewRequest("POST", "/pull", strings.NewReader(reqBody))
 	req3.Header.Add("Authorization", "sandbox")
 	mux1 := mux.NewRouter()
 	RegisterHandlers(svc1, mux1)
@@ -58,7 +62,7 @@ func TestNo301(t *testing.T) {
 	adb, adir := account.LoadTempDB(assert)
 	defer func() { assert.NoError(os.RemoveAll(adir)) }()
 
-	svc := NewService(td, adb, "", nil, true)
+	svc := NewService(td, account.MaxASClientViewURLs, adb, "", nil, true)
 	r := httptest.NewRecorder()
 
 	mux := mux.NewRouter()

--- a/serve/signup/service.go
+++ b/serve/signup/service.go
@@ -69,11 +69,11 @@ func RegisterHandlers(s *Service, router *mux.Router) {
 }
 
 func (s *Service) handle(w http.ResponseWriter, r *http.Request) {
-	// TODO auto-add ASID client view urls
-	// TODO enable multiple URLs for all accounts
+	// TODO account authorized clientview URLs should match on domain
 	// TODO better error messages for errors in POST
 	// TODO light form validation eg missing email
 	// TODO retry if concurrent POSTs step on each other + test
+	// TODO retry if saving new clientviewurl fails
 	// TODO logging
 	// TODO cache account.Records, eg only re-read every N second
 	// TODO rate limiting
@@ -100,7 +100,7 @@ func (s *Service) handle(w http.ResponseWriter, r *http.Request) {
 			serverError(w, err, s.logger)
 			return
 		}
-		accounts, err := account.ReadRecords(db)
+		accounts, err := account.ReadAllRecords(db)
 		if err != nil {
 			serverError(w, err, s.logger)
 			return

--- a/serve/types/types.go
+++ b/serve/types/types.go
@@ -10,7 +10,9 @@ type PullRequest struct {
 	// Version 0 -> uses raw json kv.Operation.Value
 	// Version 1 -> uses stringified json kv.Operation.ValueString
 	// Version 2 -> top-level remove uses replace path="" value="{}" instead of remove path="/"
+	// Version 3 -> request explicitly specifies client view URL
 	Version        uint32 `json:"version"`
+	ClientViewURL  string `json:"clientViewURL"`
 	ClientViewAuth string `json:"clientViewAuth"`
 	ClientID       string `json:"clientID"`
 	BaseStateID    string `json:"baseStateID"`


### PR DESCRIPTION
- pass clientviewurl in the PullRequest
- enable regular accounts to have multiple clientviewurls
- auto-add up to 10 clientviewurls for auto-signup accounts

Progress towards https://github.com/rocicorp/repc/issues/269